### PR TITLE
Remove cmake version in libgdf conda env

### DIFF
--- a/build-scripts/libgdf-master.sh
+++ b/build-scripts/libgdf-master.sh
@@ -11,7 +11,7 @@ logger "Check GPU usage..."
 nvidia-smi
 
 logger "Patch conda env..."
-cat conda_environments/dev_py35.yml | grep -v "cudatoolkit" > libgdf_dev.yml
+cat conda_environments/dev_py35.yml | grep -v "cudatoolkit" | grep -v "cmake" > libgdf_dev.yml
 
 logger "Create conda env..."
 rm -rf /home/jenkins/.conda/envs/libgdf_dev

--- a/build-scripts/libgdf-prb.sh
+++ b/build-scripts/libgdf-prb.sh
@@ -11,7 +11,7 @@ logger "Check GPU usage..."
 nvidia-smi
 
 logger "Patch conda env..."
-cat conda_environments/dev_py35.yml | grep -v "cudatoolkit" > libgdf_dev.yml
+cat conda_environments/dev_py35.yml | grep -v "cudatoolkit" | grep -v "cmake" > libgdf_dev.yml
 
 logger "Create conda env..."
 rm -rf /home/jenkins/.conda/envs/libgdf_dev


### PR DESCRIPTION
The conda env in libgdf installs cmake 3.6.3 when 3.12 is installed in the container and needed for building