### PR TITLE
[REVIEW] Move .condarc to conda root environment, prevent v8.2.0 compilers/libs from being installed, 

### DIFF
--- a/.condarc-cuda10.0
+++ b/.condarc-cuda10.0
@@ -5,4 +5,8 @@ channels:
   - nvidia/label/cuda10.0
   - conda-forge
   - defaults
-
+add_pip_as_python_dependency: False
+disallow:
+  - libgcc-ng ==8.2.0
+  - libstdcxx-ng ==8.2.0
+  - libgfortran-ng ==8.2.0

--- a/.condarc-cuda10.0
+++ b/.condarc-cuda10.0
@@ -5,7 +5,6 @@ channels:
   - nvidia/label/cuda10.0
   - conda-forge
   - defaults
-add_pip_as_python_dependency: False
 disallow:
   - libgcc-ng ==8.2.0
   - libstdcxx-ng ==8.2.0

--- a/.condarc-cuda9.2
+++ b/.condarc-cuda9.2
@@ -5,7 +5,6 @@ channels:
   - nvidia/label/cuda9.2
   - conda-forge
   - defaults
-add_pip_as_python_dependency: False
 disallow:
   - libgcc-ng ==8.2.0
   - libstdcxx-ng ==8.2.0

--- a/.condarc-cuda9.2
+++ b/.condarc-cuda9.2
@@ -5,4 +5,8 @@ channels:
   - nvidia/label/cuda9.2
   - conda-forge
   - defaults
-
+add_pip_as_python_dependency: False
+disallow:
+  - libgcc-ng ==8.2.0
+  - libstdcxx-ng ==8.2.0
+  - libgfortran-ng ==8.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN curl ${MINICONDA_URL} -o /miniconda.sh && \
     conda update -y -n base -c conda-forge conda
 
 # Add a condarc to remove blacklist
-ADD .condarc-cuda${CUDA_SHORT_VERSION} /root/.condarc
+ADD .condarc-cuda${CUDA_SHORT_VERSION} /conda/.condarc
 
 RUN conda create --no-default-packages -n gdf python=${PYTHON_VERSION} && \
     conda install -n gdf -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,8 @@ RUN curl ${MINICONDA_URL} -o /miniconda.sh && \
 # Add a condarc to remove blacklist
 ADD .condarc-cuda${CUDA_SHORT_VERSION} /conda/.condarc
 
-RUN conda create --no-default-packages -n gdf python=${PYTHON_VERSION} && \
-    conda install -n gdf -y \
+RUN conda create --no-default-packages -n gdf \
+      python=${PYTHON_VERSION} \
       anaconda-client \
       arrow-cpp=${ARROW_CPP_VERSION} \
       cmake=${CMAKE_VERSION} \


### PR DESCRIPTION
Moves the .condarc to the root conda environment so that it isn't `root` user specific.

Additionally, blacklists v8.2.0 compilers/libs so that they can't bite us in the butt.

Also, creates the gdf environment in one go so that there isn't any packages installed and then downgraded inadvertently.