### PR TITLE
[REVIEW] Remove blacklisted compiler packages

### DIFF
--- a/.condarc-cuda10.0
+++ b/.condarc-cuda10.0
@@ -5,7 +5,3 @@ channels:
   - nvidia/label/cuda10.0
   - conda-forge
   - defaults
-disallow:
-  - libgcc-ng ==8.2.0
-  - libstdcxx-ng ==8.2.0
-  - libgfortran-ng ==8.2.0

--- a/.condarc-cuda9.2
+++ b/.condarc-cuda9.2
@@ -5,7 +5,3 @@ channels:
   - nvidia/label/cuda9.2
   - conda-forge
   - defaults
-disallow:
-  - libgcc-ng ==8.2.0
-  - libstdcxx-ng ==8.2.0
-  - libgfortran-ng ==8.2.0


### PR DESCRIPTION
Thought the blacklist factored into the solver but seems like it doesn't and just errors if it grabs that package. Remove for now.