### PR TITLE
[REVIEW] Add python test coverage package to base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ RUN conda create --no-default-packages -n gdf \
       pandas=${PANDAS_VERSION} \
       pyarrow=${PYARROW_VERSION} \
       pytest \
+      pytest-cov \
       scikit-learn=${SKLEARN_VERSION} \
       scipy=${SCIPY_VERSION} \
       conda-forge::blas=1.1=openblas \


### PR DESCRIPTION
Since we'll be using this in conjunction with py.test, we should add this to our base Docker images instead of adding the install to the build scripts.