### PR TITLE
[REVIEW] Remove cuda labels from .condarc

### DIFF
--- a/.condarc
+++ b/.condarc
@@ -1,0 +1,6 @@
+channels:
+  - rapidsai
+  - rapidsai-nightly
+  - nvidia
+  - conda-forge
+  - defaults

--- a/.condarc-cuda10.0
+++ b/.condarc-cuda10.0
@@ -1,6 +1,0 @@
-channels:
-  - rapidsai/label/cuda10.0
-  - rapidsai-nightly/label/cuda10.0
-  - nvidia/label/cuda10.0
-  - conda-forge
-  - defaults

--- a/.condarc-cuda9.2
+++ b/.condarc-cuda9.2
@@ -1,6 +1,0 @@
-channels:
-  - rapidsai/label/cuda9.2
-  - rapidsai-nightly/label/cuda9.2
-  - nvidia/label/cuda9.2
-  - conda-forge
-  - defaults

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN curl ${MINICONDA_URL} -o /miniconda.sh && \
     conda update -y -n base -c conda-forge conda
 
 # Add a condarc to remove blacklist
-ADD .condarc-cuda${CUDA_SHORT_VERSION} /conda/.condarc
+ADD .condarc /conda/.condarc
 
 RUN conda create --no-default-packages -n gdf \
       python=${PYTHON_VERSION} \

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -137,7 +137,7 @@ RUN curl ${MINICONDA_URL} -o /miniconda.sh && \
     rm -f /miniconda.sh && \
     conda update -y -n base -c conda-forge conda
 
-ADD .condarc-cuda${CUDA_SHORT_VERSION} /conda/.condarc
+ADD .condarc /conda/.condarc
 
 RUN conda create --no-default-packages -n gdf \
       python=${PYTHON_VERSION} \


### PR DESCRIPTION
Since the CUDA version is now controlled by the `cudatoolkit` conda package, the labels should be removed.