### PR TITLE
Add `black` and `isort` to the gpuci environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,61 +41,61 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Update and add pkgs
 RUN apt-get update -y --fix-missing && \
-  apt-get upgrade -y && \
-  apt-get -qq install apt-utils -y --no-install-recommends && \
-  apt-get install -y \
-  curl \
-  git \
-  screen \
-  gcc-${CC_VERSION} \
-  g++-${CXX_VERSION} \
-  libboost-all-dev \
-  tzdata \
-  wget \
-  vim \
-  zlib1g-dev \
-  && rm -rf /var/lib/apt/lists/*
+    apt-get upgrade -y && \
+    apt-get -qq install apt-utils -y --no-install-recommends && \
+    apt-get install -y \
+      curl \
+      git \
+      screen \
+      gcc-${CC_VERSION} \
+      g++-${CXX_VERSION} \
+      libboost-all-dev \
+      tzdata \
+      wget \
+      vim \
+      zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install conda
 ## Build combined libgdf/pygdf conda env
 RUN curl ${MINICONDA_URL} -o /miniconda.sh && \
-  sh /miniconda.sh -b -p /conda && \
-  rm -f /miniconda.sh && \
-  echo "conda ${CONDA_VERSION}" >> /conda/conda-meta/pinned
+    sh /miniconda.sh -b -p /conda && \
+    rm -f /miniconda.sh && \
+    echo "conda ${CONDA_VERSION}" >> /conda/conda-meta/pinned
 
 # Add a condarc to remove blacklist
 ADD .condarc-cuda${CUDA_SHORT_VERSION} /conda/.condarc
 
 RUN conda create --no-default-packages -n gdf \
-  python=${PYTHON_VERSION} \
-  anaconda-client \
-  arrow-cpp=${ARROW_CPP_VERSION} \
-  cmake=${CMAKE_VERSION} \
-  cmake_setuptools \
-  conda=${CONDA_VERSION} \
-  conda-build=${CONDA_BUILD_VERSION} \
-  conda-verify=${CONDA_VERIFY_VERSION} \
-  cffi=${CFFI_VERSION} \
-  cmake=${CMAKE_VERSION} \
-  cython=${CYTHON_VERSION} \
-  flake8 \
-  black \
-  isort \
-  make \
-  numba>=${NUMBA_VERSION} \
-  numpy=${NUMPY_VERSION} \
-  pandas=${PANDAS_VERSION} \
-  pyarrow=${PYARROW_VERSION} \
-  pytest \
-  pytest-cov \
-  scikit-learn=${SKLEARN_VERSION} \
-  scipy=${SCIPY_VERSION} \
-  conda-forge::blas=1.1=openblas \
-  libgcc-ng=${LIBGCC_NG_VERSION} \
-  libgfortran-ng=${LIBGFORTRAIN_NG_VERSION} \
-  libstdcxx-ng=${LIBSTDCXX_NG_VERSION} \
-  && conda clean -a && \
-  chmod 777 -R /conda
+      python=${PYTHON_VERSION} \
+      anaconda-client \
+      arrow-cpp=${ARROW_CPP_VERSION} \
+      cmake=${CMAKE_VERSION} \
+      cmake_setuptools \
+      conda=${CONDA_VERSION} \
+      conda-build=${CONDA_BUILD_VERSION} \
+      conda-verify=${CONDA_VERIFY_VERSION} \
+      cffi=${CFFI_VERSION} \
+      cmake=${CMAKE_VERSION} \
+      cython=${CYTHON_VERSION} \
+      flake8 \
+      black \
+      isort \
+      make \
+      numba>=${NUMBA_VERSION} \
+      numpy=${NUMPY_VERSION} \
+      pandas=${PANDAS_VERSION} \
+      pyarrow=${PYARROW_VERSION} \
+      pytest \
+      pytest-cov \
+      scikit-learn=${SKLEARN_VERSION} \
+      scipy=${SCIPY_VERSION} \
+      conda-forge::blas=1.1=openblas \
+      libgcc-ng=${LIBGCC_NG_VERSION} \
+      libgfortran-ng=${LIBGFORTRAIN_NG_VERSION} \
+      libstdcxx-ng=${LIBSTDCXX_NG_VERSION} \
+    && conda clean -a && \
+    chmod 777 -R /conda
 
 ## Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,59 +41,61 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Update and add pkgs
 RUN apt-get update -y --fix-missing && \
-    apt-get upgrade -y && \
-    apt-get -qq install apt-utils -y --no-install-recommends && \
-    apt-get install -y \
-      curl \
-      git \
-      screen \
-      gcc-${CC_VERSION} \
-      g++-${CXX_VERSION} \
-      libboost-all-dev \
-      tzdata \
-      wget \
-      vim \
-      zlib1g-dev \
-    && rm -rf /var/lib/apt/lists/*
+  apt-get upgrade -y && \
+  apt-get -qq install apt-utils -y --no-install-recommends && \
+  apt-get install -y \
+  curl \
+  git \
+  screen \
+  gcc-${CC_VERSION} \
+  g++-${CXX_VERSION} \
+  libboost-all-dev \
+  tzdata \
+  wget \
+  vim \
+  zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install conda
 ## Build combined libgdf/pygdf conda env
 RUN curl ${MINICONDA_URL} -o /miniconda.sh && \
-    sh /miniconda.sh -b -p /conda && \
-    rm -f /miniconda.sh && \
-    echo "conda ${CONDA_VERSION}" >> /conda/conda-meta/pinned
+  sh /miniconda.sh -b -p /conda && \
+  rm -f /miniconda.sh && \
+  echo "conda ${CONDA_VERSION}" >> /conda/conda-meta/pinned
 
 # Add a condarc to remove blacklist
 ADD .condarc-cuda${CUDA_SHORT_VERSION} /conda/.condarc
 
 RUN conda create --no-default-packages -n gdf \
-      python=${PYTHON_VERSION} \
-      anaconda-client \
-      arrow-cpp=${ARROW_CPP_VERSION} \
-      cmake=${CMAKE_VERSION} \
-      cmake_setuptools \
-      conda=${CONDA_VERSION} \
-      conda-build=${CONDA_BUILD_VERSION} \
-      conda-verify=${CONDA_VERIFY_VERSION} \
-      cffi=${CFFI_VERSION} \
-      cmake=${CMAKE_VERSION} \
-      cython=${CYTHON_VERSION} \
-      flake8 \
-      make \
-      numba>=${NUMBA_VERSION} \
-      numpy=${NUMPY_VERSION} \
-      pandas=${PANDAS_VERSION} \
-      pyarrow=${PYARROW_VERSION} \
-      pytest \
-      pytest-cov \
-      scikit-learn=${SKLEARN_VERSION} \
-      scipy=${SCIPY_VERSION} \
-      conda-forge::blas=1.1=openblas \
-      libgcc-ng=${LIBGCC_NG_VERSION} \
-      libgfortran-ng=${LIBGFORTRAIN_NG_VERSION} \
-      libstdcxx-ng=${LIBSTDCXX_NG_VERSION} \
-    && conda clean -a && \
-    chmod 777 -R /conda
+  python=${PYTHON_VERSION} \
+  anaconda-client \
+  arrow-cpp=${ARROW_CPP_VERSION} \
+  cmake=${CMAKE_VERSION} \
+  cmake_setuptools \
+  conda=${CONDA_VERSION} \
+  conda-build=${CONDA_BUILD_VERSION} \
+  conda-verify=${CONDA_VERIFY_VERSION} \
+  cffi=${CFFI_VERSION} \
+  cmake=${CMAKE_VERSION} \
+  cython=${CYTHON_VERSION} \
+  flake8 \
+  black \
+  isort \
+  make \
+  numba>=${NUMBA_VERSION} \
+  numpy=${NUMPY_VERSION} \
+  pandas=${PANDAS_VERSION} \
+  pyarrow=${PYARROW_VERSION} \
+  pytest \
+  pytest-cov \
+  scikit-learn=${SKLEARN_VERSION} \
+  scipy=${SCIPY_VERSION} \
+  conda-forge::blas=1.1=openblas \
+  libgcc-ng=${LIBGCC_NG_VERSION} \
+  libgfortran-ng=${LIBGFORTRAIN_NG_VERSION} \
+  libstdcxx-ng=${LIBSTDCXX_NG_VERSION} \
+  && conda clean -a && \
+  chmod 777 -R /conda
 
 ## Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -69,8 +69,8 @@ RUN mkdir -p ${RAPIDS_SRC_DIR}/tmp
 COPY ${SUPPORT_FILES_DIR}/*.rpm ${RAPIDS_SRC_DIR}/tmp
 
 RUN yum install -y ${RAPIDS_SRC_DIR}/tmp/*.rpm && \
-    yum upgrade -y && \
-    yum install -y \
+      yum upgrade -y && \
+      yum install -y \
       bzip2 \
       curl \
       git \
@@ -86,7 +86,7 @@ RUN yum install -y ${RAPIDS_SRC_DIR}/tmp/*.rpm && \
       gmp-devel mpfr-devel libmpc-devel file
 
 RUN curl -L ${TINI_URL} -o /usr/bin/tini && \
-    chmod +x /usr/bin/tini
+      chmod +x /usr/bin/tini
 
 RUN rm -rf ${RAPIDS_SRC_DIR}/tmp
 # NOTE: Copying a pre-built gcc7 could be an option to avoid the
@@ -112,8 +112,8 @@ RUN mkdir -p ${GCC7_DIR}
 RUN cd ${GCC7_DIR} && wget -q http://ftp.gnu.org/gnu/gcc/gcc-7.2.0/gcc-7.2.0.tar.gz
 RUN cd ${GCC7_DIR} && tar zxf gcc-7.2.0.tar.gz
 RUN cd ${GCC7_DIR}/gcc-7.2.0 && \
-    ./configure --prefix=${GCC7_DIR} --disable-multilib && \
-    make -j${NUM_BUILD_CPUS} && make install
+      ./configure --prefix=${GCC7_DIR} --disable-multilib && \
+      make -j${NUM_BUILD_CPUS} && make install
 
 # Remove gcc source dir and tarfile
 RUN rm -r ${GCC7_DIR}/gcc-7.2.0 ${GCC7_DIR}/gcc-7.2.0.tar.gz
@@ -136,9 +136,9 @@ ENV LD_LIBRARY_PATH_POSTBUILD=${GCC7_DIR}/lib64:$LD_LIBRARY_PATH_POSTBUILD
 # Install conda
 ## Build combined libgdf/pygdf conda env
 RUN curl ${MINICONDA_URL} -o /miniconda.sh && \
-    sh /miniconda.sh -b -p /conda && \
-    rm -f /miniconda.sh && \
-    echo "conda ${CONDA_VERSION}" >> /conda/conda-meta/pinned
+      sh /miniconda.sh -b -p /conda && \
+      rm -f /miniconda.sh && \
+      echo "conda ${CONDA_VERSION}" >> /conda/conda-meta/pinned
 
 ADD .condarc-cuda${CUDA_SHORT_VERSION} /conda/.condarc
 
@@ -155,6 +155,8 @@ RUN conda create --no-default-packages -n gdf \
       cmake=${CMAKE_VERSION} \
       cython=${CYTHON_VERSION} \
       flake8 \
+      black \
+      isort \
       make \
       numba>=${NUMBA_VERSION} \
       numpy=${NUMPY_VERSION} \
@@ -168,8 +170,8 @@ RUN conda create --no-default-packages -n gdf \
       libgcc-ng=${LIBGCC_NG_VERSION} \
       libgfortran-ng=${LIBGFORTRAIN_NG_VERSION} \
       libstdcxx-ng=${LIBSTDCXX_NG_VERSION} \
-    && conda clean -a && \
-    chmod 777 -R /conda
+      && conda clean -a && \
+      chmod 777 -R /conda
 
 # Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -69,8 +69,8 @@ RUN mkdir -p ${RAPIDS_SRC_DIR}/tmp
 COPY ${SUPPORT_FILES_DIR}/*.rpm ${RAPIDS_SRC_DIR}/tmp
 
 RUN yum install -y ${RAPIDS_SRC_DIR}/tmp/*.rpm && \
-      yum upgrade -y && \
-      yum install -y \
+    yum upgrade -y && \
+    yum install -y \
       bzip2 \
       curl \
       git \
@@ -86,7 +86,7 @@ RUN yum install -y ${RAPIDS_SRC_DIR}/tmp/*.rpm && \
       gmp-devel mpfr-devel libmpc-devel file
 
 RUN curl -L ${TINI_URL} -o /usr/bin/tini && \
-      chmod +x /usr/bin/tini
+    chmod +x /usr/bin/tini
 
 RUN rm -rf ${RAPIDS_SRC_DIR}/tmp
 # NOTE: Copying a pre-built gcc7 could be an option to avoid the
@@ -112,8 +112,8 @@ RUN mkdir -p ${GCC7_DIR}
 RUN cd ${GCC7_DIR} && wget -q http://ftp.gnu.org/gnu/gcc/gcc-7.2.0/gcc-7.2.0.tar.gz
 RUN cd ${GCC7_DIR} && tar zxf gcc-7.2.0.tar.gz
 RUN cd ${GCC7_DIR}/gcc-7.2.0 && \
-      ./configure --prefix=${GCC7_DIR} --disable-multilib && \
-      make -j${NUM_BUILD_CPUS} && make install
+    ./configure --prefix=${GCC7_DIR} --disable-multilib && \
+    make -j${NUM_BUILD_CPUS} && make install
 
 # Remove gcc source dir and tarfile
 RUN rm -r ${GCC7_DIR}/gcc-7.2.0 ${GCC7_DIR}/gcc-7.2.0.tar.gz
@@ -136,9 +136,9 @@ ENV LD_LIBRARY_PATH_POSTBUILD=${GCC7_DIR}/lib64:$LD_LIBRARY_PATH_POSTBUILD
 # Install conda
 ## Build combined libgdf/pygdf conda env
 RUN curl ${MINICONDA_URL} -o /miniconda.sh && \
-      sh /miniconda.sh -b -p /conda && \
-      rm -f /miniconda.sh && \
-      echo "conda ${CONDA_VERSION}" >> /conda/conda-meta/pinned
+    sh /miniconda.sh -b -p /conda && \
+    rm -f /miniconda.sh && \
+    echo "conda ${CONDA_VERSION}" >> /conda/conda-meta/pinned
 
 ADD .condarc-cuda${CUDA_SHORT_VERSION} /conda/.condarc
 
@@ -170,8 +170,8 @@ RUN conda create --no-default-packages -n gdf \
       libgcc-ng=${LIBGCC_NG_VERSION} \
       libgfortran-ng=${LIBGFORTRAIN_NG_VERSION} \
       libstdcxx-ng=${LIBSTDCXX_NG_VERSION} \
-      && conda clean -a && \
-      chmod 777 -R /conda
+    && conda clean -a && \
+    chmod 777 -R /conda
 
 # Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
This will be to run them in check only mode as part of the style checker for cudf but will encourage other libraries to use them as well.