### PR TITLE
FIX Pin libarchive version to fix zstd conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ARG FASTAVRO_VERSION=0.22.3
 ARG DLPACK_VERSION=0.2
 ARG SKLEARN_VERSION=0.21.3
 ARG SCIPY_VERSION=1.3.0
+ARG LIBARCHIVE_VERSION=3.4.0
 ARG LIBGCC_NG_VERSION=7.3.0
 ARG LIBGFORTRAN_NG_VERSION=7.3.0
 ARG LIBSTDCXX_NG_VERSION=7.3.0
@@ -97,6 +98,7 @@ RUN conda create --no-default-packages -n gdf \
       flake8 \
       black \
       isort \
+      libarchive=${LIBARCHIVE_VERSION} \
       make \
       numba">=${NUMBA_VERSION}" \
       numpy=${NUMPY_VERSION} \

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -25,6 +25,7 @@ ARG FASTAVRO_VERSION=0.22.3
 ARG DLPACK_VERSION=0.2
 ARG SKLEARN_VERSION=0.21.3
 ARG SCIPY_VERSION=1.3.0
+ARG LIBARCHIVE_VERSION=3.4.0
 ARG LIBGCC_NG_VERSION=7.3.0
 ARG LIBGFORTRAN_NG_VERSION=7.3.0
 ARG LIBSTDCXX_NG_VERSION=7.3.0
@@ -108,6 +109,7 @@ RUN conda create --no-default-packages -n gdf \
       flake8 \
       black \
       isort \
+      libarchive=${LIBARCHIVE_VERSION} \
       make \
       numba">=${NUMBA_VERSION}" \
       numpy=${NUMPY_VERSION} \


### PR DESCRIPTION
New pyarrow/arrow-cpp 0.15.1 require zstd 1.4.3, libarchive 3.4.0 requires the same version