### PR TITLE
[REVIEW] Python 3.5 images

### DIFF
--- a/python3.5/Dockerfile
+++ b/python3.5/Dockerfile
@@ -1,0 +1,129 @@
+ARG FROM_IMAGE=nvidia/cuda
+ARG CUDA_VERSION=9.2
+ARG CUDA_SHORT_VERSION=${CUDA_VERSION}
+ARG LINUX_VERSION=ubuntu16.04
+FROM ${FROM_IMAGE}:${CUDA_VERSION}-devel-${LINUX_VERSION}
+
+# Define arguments
+ARG CUDA_SHORT_VERSION
+ARG CC_VERSION=5
+ARG CXX_VERSION=5
+ARG PYTHON_VERSION=3.5
+ARG CFFI_VERSION=1.11.5
+ARG CYTHON_VERSION=0.28
+ARG CMAKE_VERSION=3.14.5
+ARG NUMBA_VERSION=0.38.1
+ARG NUMPY_VERSION=1.13.3
+ARG PANDAS_VERSION=0.23.4
+ARG PYARROW_VERSION=0.10.0
+ARG ARROW_CPP_VERSION=0.10.0
+ARG DOUBLE_CONVERSION_VERSION=3.1.5
+ARG RAPIDJSON_VERSION=1.1.0
+ARG FLATBUFFERS_VERSION=1.10.0
+ARG BOOST_CPP_VERSION=1.67.0
+ARG FASTAVRO_VERSION=0.20.0
+ARG DLPACK_VERSION=0.2
+ARG SKLEARN_VERSION=0.19.2
+ARG SCIPY_VERSION=1.1.0
+ARG LIBGCC_NG_VERSION=7.3.0
+ARG LIBGFORTRAN_NG_VERSION=7.3.0
+ARG LIBSTDCXX_NG_VERSION=7.3.0
+ARG TINI_VERSION=v0.18.0
+ARG HASH_JOIN=ON
+ARG CONDA_VERSION=4.3.31
+ARG CONDA_BUILD_VERSION=3.14.4
+ARG CONDA_VERIFY_VERSION=3.1.1
+ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh
+
+# Set environment
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
+ENV CUDA_HOME=/usr/local/cuda
+ENV CC=/usr/bin/gcc-${CC_VERSION}
+ENV CXX=/usr/bin/g++-${CXX_VERSION}
+ENV CUDAHOSTCXX=/usr/bin/g++-${CXX_VERSION}
+ENV PATH=${PATH}:/conda/bin
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update and add pkgs
+RUN apt-get update -y --fix-missing && \
+      apt-get upgrade -y && \
+      apt-get -qq install apt-utils -y --no-install-recommends && \
+      apt-get install -y \
+        awscli \
+        curl \
+        git \
+        jq \
+        screen \
+        gcc-${CC_VERSION} \
+        g++-${CXX_VERSION} \
+        libnuma1 \
+        libnuma-dev \
+        tzdata \
+        wget \
+        vim \
+        zlib1g-dev \
+      && rm -rf /var/lib/apt/lists/*
+
+# Install conda
+RUN curl ${MINICONDA_URL} -k -o /miniconda.sh \
+      && sh /miniconda.sh -b -p /conda \
+      && rm -f /miniconda.sh \
+      && echo "conda ${CONDA_VERSION}" >> /conda/conda-meta/pinned
+
+# Add a condarc
+ADD .condarc /conda/.condarc
+
+# Add utlities to base env
+RUN conda install -y \
+      anaconda-client \
+      codecov \
+      conda=${CONDA_VERSION} \
+      conda-build=${CONDA_BUILD_VERSION} \
+      conda-verify=${CONDA_VERIFY_VERSION} \
+      ripgrep
+
+# Create gdf conda env
+RUN conda create --no-default-packages -n gdf \
+      python=${PYTHON_VERSION} \
+      arrow-cpp=${ARROW_CPP_VERSION} \
+      cffi=${CFFI_VERSION} \
+      cmake=${CMAKE_VERSION} \
+      cmake_setuptools \
+      # conda=${CONDA_VERSION} \
+      # conda-build=${CONDA_BUILD_VERSION} \
+      conda-verify=${CONDA_VERIFY_VERSION} \
+      cudatoolkit=${CUDA_SHORT_VERSION} \
+      cython=${CYTHON_VERSION} \
+      flake8 \
+      # black \
+      isort \
+      make \
+      numba">=${NUMBA_VERSION}" \
+      numpy=${NUMPY_VERSION} \
+      pandas=${PANDAS_VERSION} \
+      pyarrow=${PYARROW_VERSION} \
+      double-conversion=${DOUBLE_CONVERSION_VERSION} \
+      rapidjson=${RAPIDJSON_VERSION} \
+      flatbuffers=${FLATBUFFERS_VERSION} \
+      boost-cpp=${BOOST_CPP_VERSION} \
+      fastavro=${FASTAVRO_VERSION} \
+      dlpack=${DLPACK_VERSION} \
+      pytest \
+      pytest-cov \
+      scikit-learn=${SKLEARN_VERSION} \
+      scipy=${SCIPY_VERSION} \
+      blas=1.1=openblas \
+      libgcc-ng=${LIBGCC_NG_VERSION} \
+      libgfortran-ng=${LIBGFORTRAN_NG_VERSION} \
+      libstdcxx-ng=${LIBSTDCXX_NG_VERSION} \
+    && conda clean -ay \
+    && chmod -R ugo+w /conda
+
+## Enables "source activate conda"
+SHELL ["/bin/bash", "-c"]
+
+RUN curl -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /usr/bin/tini && \
+      chmod +x /usr/bin/tini
+
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+CMD [ "/bin/bash" ]

--- a/python3.5/Dockerfile.centos7
+++ b/python3.5/Dockerfile.centos7
@@ -1,0 +1,144 @@
+ARG FROM_IMAGE=nvidia/cuda
+ARG CUDA_VERSION=10.0
+ARG CUDA_SHORT_VERSION=${CUDA_VERSION}
+ARG LINUX_VERSION=centos7
+FROM ${FROM_IMAGE}:${CUDA_VERSION}-devel-${LINUX_VERSION}
+
+# Define arguments
+ARG CUDA_SHORT_VERSION
+ARG CC_VERSION=7
+ARG CXX_VERSION=7
+ARG PYTHON_VERSION=3.5
+ARG CFFI_VERSION=1.11.5
+ARG CYTHON_VERSION=0.28
+ARG CMAKE_VERSION=3.14.5
+ARG NUMBA_VERSION=0.38.1
+ARG NUMPY_VERSION=1.13.3
+ARG PANDAS_VERSION=0.23.4
+ARG PYARROW_VERSION=0.10.0
+ARG ARROW_CPP_VERSION=0.10.0
+ARG DOUBLE_CONVERSION_VERSION=3.1.5
+ARG RAPIDJSON_VERSION=1.1.0
+ARG FLATBUFFERS_VERSION=1.10.0
+ARG BOOST_CPP_VERSION=1.67.0
+ARG FASTAVRO_VERSION=0.20.0
+ARG DLPACK_VERSION=0.2
+ARG SKLEARN_VERSION=0.19.2
+ARG SCIPY_VERSION=1.1.0
+ARG LIBGCC_NG_VERSION=7.3.0
+ARG LIBGFORTRAN_NG_VERSION=7.3.0
+ARG LIBSTDCXX_NG_VERSION=7.3.0
+ARG TINI_VERSION=v0.18.0
+ARG HASH_JOIN=ON
+ARG CONDA_VERSION=4.3.31
+ARG CONDA_BUILD_VERSION=3.14.4
+ARG CONDA_VERIFY_VERSION=3.1.1
+ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh
+
+# Add /usr/local/cuda/* temporarily to LD_LIBRARY_PATH to support various build steps
+# This will need to be removed later since it causes problems with certain runtime libs (numba.cuda)
+ENV LD_LIBRARY_PATH_POSTBUILD=$LD_LIBRARY_PATH
+
+ENV PATH=$PATH:/conda/bin
+
+RUN yum upgrade -y \
+    && yum install -y \
+      awscli \
+      bzip2 \
+      curl \
+      git \
+      screen \
+      vim \
+      wget \
+      which \
+      clang \
+      make \
+      numactl-libs \
+      numactl-devel \
+      patch
+
+RUN curl 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64' -L -k -o /usr/local/bin/jq && \
+      chmod +x /usr/local/bin/jq
+
+# Install gcc7 from prebuilt image
+COPY --from=gpuci/builds-gcc7:10.0-devel-centos7 /usr/local/gcc7 /usr/local/gcc7
+
+# Update environment to use new gcc7
+ENV GCC7_DIR=/usr/local/gcc7
+ENV CC=${GCC7_DIR}/bin/gcc
+ENV CXX=${GCC7_DIR}/bin/g++
+ENV CUDAHOSTCXX=${GCC7_DIR}/bin/g++
+ENV LD_LIBRARY_PATH=${GCC7_DIR}/lib64:/conda/envs/gdf
+ENV CUDA_HOME=/usr/local/cuda
+ENV PATH=/conda/bin:$PATH
+ENV PATH=${GCC7_DIR}/bin:$PATH
+
+# NOTE: Many/all of the package versions used below are defined in the
+# "args" insertfile
+
+# Install conda
+RUN curl ${MINICONDA_URL} -k -o /miniconda.sh \
+      && sh /miniconda.sh -b -p /conda \
+      && rm -f /miniconda.sh \
+      && echo "conda ${CONDA_VERSION}" >> /conda/conda-meta/pinned
+
+# Add a condarc
+ADD .condarc /conda/.condarc
+
+# Add utlities to base env
+RUN conda install -y \
+      codecov \
+      conda=${CONDA_VERSION} \
+      conda-build=${CONDA_BUILD_VERSION} \
+      conda-verify=${CONDA_VERIFY_VERSION} \
+      ripgrep
+
+# Create gdf conda env
+RUN conda create --no-default-packages -n gdf \
+      python=${PYTHON_VERSION} \
+      anaconda-client \
+      arrow-cpp=${ARROW_CPP_VERSION} \
+      cffi=${CFFI_VERSION} \
+      cmake=${CMAKE_VERSION} \
+      cmake_setuptools \
+      # conda=${CONDA_VERSION} \
+      # conda-build=${CONDA_BUILD_VERSION} \
+      conda-verify=${CONDA_VERIFY_VERSION} \
+      cudatoolkit=${CUDA_SHORT_VERSION} \
+      cython=${CYTHON_VERSION} \
+      flake8 \
+      # black \
+      isort \
+      make \
+      numba">=${NUMBA_VERSION}" \
+      numpy=${NUMPY_VERSION} \
+      pandas=${PANDAS_VERSION} \
+      pyarrow=${PYARROW_VERSION} \
+      double-conversion=${DOUBLE_CONVERSION_VERSION} \
+      rapidjson=${RAPIDJSON_VERSION} \
+      flatbuffers=${FLATBUFFERS_VERSION} \
+      boost-cpp=${BOOST_CPP_VERSION} \
+      fastavro=${FASTAVRO_VERSION} \
+      dlpack=${DLPACK_VERSION} \
+      pytest \
+      pytest-cov \
+      scikit-learn=${SKLEARN_VERSION} \
+      scipy=${SCIPY_VERSION} \
+      blas=1.1=openblas \
+      libgcc-ng=${LIBGCC_NG_VERSION} \
+      libgfortran-ng=${LIBGFORTRAN_NG_VERSION} \
+      libstdcxx-ng=${LIBSTDCXX_NG_VERSION} \
+    && conda clean -ay \
+    && chmod -R ugo+w /conda
+
+# xgboost build will not find nccl in the conda env without this env var
+ENV NCCL_ROOT=/conda/envs/gdf
+
+# Enables "source activate conda"
+SHELL ["/bin/bash", "-c"]
+
+RUN curl -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /usr/bin/tini && \
+      chmod +x /usr/bin/tini
+
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
There was an ask to create Python 3.5 images. Unfortunately, many of the library versions we use are Python >=3.6.

So I downgraded the dependencies to Python 3.5 compatible versions. The only package that doesn't have a compatible version is `black`.

This also meant a lower conda version which had some implications:
- No conda install in non-base environment
- No conda-build in  non-base environment since it depends on conda
- `conda clean` command has different flags

Note that no changes to `Dockerfile.drivers` are necessary. It just has to be built with `--build-arg PYTHON_VERSION=3.5`.

| Libary  | Python 3.6 | Python 3.5 |
| - | - | - |
| cython  | 0.29 | 0.28 |
| numba | 0.46.0 | 0.38.1 |
| numpy | 1.17.3 | 1.13.3 |
| pandas | 0.24.2 | 0.23.4 |
| pyarrow | 0.15.0 | 0.10.0 |
| arrow-cpp | 0.15.0 | 0.10.0 |
| boost-cpp | 1.70.0 | 1.67.0 |
| fastavro | 0.22.4 | 0.20.0 |
| sklearn | 0.21.3 | 0.19.2 |
| scipy | 1.3.0 | 0.1.0 |
| conda | 4.7.12 | 4.3.31 |
| conda-build | 3.18.11 | 3.14.4 |
