### PR TITLE
Add CuPy 6.6.0 to the gpuCI containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG CC_VERSION=5
 ARG CXX_VERSION=5
 ARG PYTHON_VERSION=3.6
 ARG CFFI_VERSION=1.11.5
+ARG CUPY_VERSION=6.6.0
 ARG CYTHON_VERSION=0.29
 ARG CMAKE_VERSION=3.14.5
 ARG NUMBA_VERSION=0.46.0
@@ -95,6 +96,7 @@ RUN conda create --no-default-packages -n gdf \
       conda-build=${CONDA_BUILD_VERSION} \
       conda-verify=${CONDA_VERIFY_VERSION} \
       cudatoolkit=${CUDA_SHORT_VERSION} \
+      cupy=${CUPY_VERSION} \
       cython=${CYTHON_VERSION} \
       flake8 \
       black \

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -10,6 +10,7 @@ ARG CC_VERSION=7
 ARG CXX_VERSION=7
 ARG PYTHON_VERSION=3.6
 ARG CFFI_VERSION=1.11.5
+ARG CUPY_VERSION=6.6.0
 ARG CYTHON_VERSION=0.29
 ARG CMAKE_VERSION=3.14.5
 ARG NUMBA_VERSION=0.46.0
@@ -107,6 +108,7 @@ RUN conda create --no-default-packages -n gdf \
       conda-build=${CONDA_BUILD_VERSION} \
       conda-verify=${CONDA_VERIFY_VERSION} \
       cudatoolkit=${CUDA_SHORT_VERSION} \
+      cupy=${CUPY_VERSION} \
       cython=${CYTHON_VERSION} \
       flake8 \
       black \


### PR DESCRIPTION
Following up on [this comment]( https://github.com/rapidsai/rmm/pull/198#discussion_r357772519 ) to add CuPy to the gpuCI containers. Starting off with the version of CuPy we used in the RAPIDS 0.11.0 release (namely 6.6.0). Though we may want to bump this to CuPy 7.0.0 in the future.

cc @raydouglass @madsbk @kkraus14 @harrism @mike-wendt