### PR TITLE
FIX Remove clean command [skip-ci]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,6 @@ RUN conda create --no-default-packages -n gdf \
       rapidsai::libclang=${LIBCLANG_VERSION} \
       librdkafka=${LIBRDKAFKA_VERSION} \
       twine \
-    && conda clean -afy \
     && chmod -R ugo+w /conda
 
 ## Enables "source activate conda"

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -135,7 +135,6 @@ RUN conda create --no-default-packages -n gdf \
       rapidsai::libclang=${LIBCLANG_VERSION} \
       librdkafka=${LIBRDKAFKA_VERSION} \
       twine \
-    && conda clean -afy \
     && chmod -R ugo+w /conda
 
 # xgboost build will not find nccl in the conda env without this env var


### PR DESCRIPTION
Clean shrinks the image but it also removes the packages. So for conda builds they have to download them again which increases build time