### PR TITLE
Patch nvidia-smi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,9 +128,9 @@ RUN conda create --no-default-packages -n gdf \
     && chmod -R ugo+w /conda
 
 ## Patch nvidia-smi to return only 0 exit codes
-RUN mv /usr/bin/nvidia-smi /usr/bin/nvidia-smi-orig &&
-    echo 'nvidia-smi-orig $@ || true' > /usr/bin/nvidia-smi &&
-    chmod +x /usr/bin/nvidia-smi
+RUN mv /usr/bin/nvidia-smi /usr/bin/nvidia-smi-orig \
+    && echo 'nvidia-smi-orig $@ || true' > /usr/bin/nvidia-smi \
+    && chmod +x /usr/bin/nvidia-smi
 
 ## Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,11 @@ RUN conda create --no-default-packages -n gdf \
     && conda clean -afy \
     && chmod -R ugo+w /conda
 
+## Patch nvidia-smi to return only 0 exit codes
+RUN mv /usr/bin/nvidia-smi /usr/bin/nvidia-smi-orig &&
+    echo 'nvidia-smi-orig $@ || true' > /usr/bin/nvidia-smi &&
+    chmod +x /usr/bin/nvidia-smi
+
 ## Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]
 

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -139,6 +139,11 @@ RUN conda create --no-default-packages -n gdf \
     && conda clean -afy \
     && chmod -R ugo+w /conda
 
+## Patch nvidia-smi to return only 0 exit codes
+RUN mv /usr/bin/nvidia-smi /usr/bin/nvidia-smi-orig \
+    && echo 'nvidia-smi-orig $@ || true' > /usr/bin/nvidia-smi \
+    && chmod +x /usr/bin/nvidia-smi
+
 # xgboost build will not find nccl in the conda env without this env var
 ENV NCCL_ROOT=/conda/envs/gdf
 


### PR DESCRIPTION
Several systems on AWS are returning inforom errors which are ending tests, this is to patch them so tests can complete