### PR TITLE
[REVIEW] Use standard clang and clang-tools package instead of libclang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ARG SCIPY_VERSION=1.3.0
 ARG LIBGCC_NG_VERSION=7.3.0
 ARG LIBGFORTRAN_NG_VERSION=7.3.0
 ARG LIBSTDCXX_NG_VERSION=7.3.0
-ARG LIBCLANG_VERSION=8.0.0
+ARG CLANG_VERSION=8
 ARG LIBRDKAFKA_VERSION=1.2.2
 ARG OPENBLAS_VERSION=2.14
 ARG TINI_VERSION=v0.18.0
@@ -121,7 +121,8 @@ RUN conda create --no-default-packages -n gdf \
       libgcc-ng=${LIBGCC_NG_VERSION} \
       libgfortran-ng=${LIBGFORTRAN_NG_VERSION} \
       libstdcxx-ng=${LIBSTDCXX_NG_VERSION} \
-      rapidsai::libclang=${LIBCLANG_VERSION} \
+      conda-forge::clang=${CLANG_VERSION} \
+      conda-forge::clang-tools=${CLANG_VERSION} \
       librdkafka=${LIBRDKAFKA_VERSION} \
       twine \
     && conda clean -afy \

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -29,7 +29,7 @@ ARG SCIPY_VERSION=1.3.0
 ARG LIBGCC_NG_VERSION=7.3.0
 ARG LIBGFORTRAN_NG_VERSION=7.3.0
 ARG LIBSTDCXX_NG_VERSION=7.3.0
-ARG LIBCLANG_VERSION=8.0.0
+ARG CLANG_VERSION=8
 ARG LIBRDKAFKA_VERSION=1.2.2
 ARG OPENBLAS_VERSION=2.14
 ARG TINI_VERSION=v0.18.0
@@ -133,7 +133,8 @@ RUN conda create --no-default-packages -n gdf \
       libgcc-ng=${LIBGCC_NG_VERSION} \
       libgfortran-ng=${LIBGFORTRAN_NG_VERSION} \
       libstdcxx-ng=${LIBSTDCXX_NG_VERSION} \
-      rapidsai::libclang=${LIBCLANG_VERSION} \
+      conda-forge::clang=${CLANG_VERSION} \
+      conda-forge::clang-tools=${CLANG_VERSION} \
       librdkafka=${LIBRDKAFKA_VERSION} \
       twine \
     && conda clean -afy \


### PR DESCRIPTION
`rapidsai::libclang` was a package for temporary usage until conda-forge clang and clang-tools packages were properly backported for their version 8 releases. Now that we have these 2 packages available on conda-forge for version 8, it is better for us to use them.

This update is also needed for the following 2 PRs in cuML:
1. https://github.com/rapidsai/cuml/pull/1972
2. https://github.com/rapidsai/cuml/pull/1945