### PR TITLE
Add pytest-timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,7 @@ RUN conda create --no-default-packages -n gdf \
       dlpack=${DLPACK_VERSION} \
       pytest \
       pytest-cov \
+      pytest-timeout \
       scikit-learn=${SKLEARN_VERSION} \
       scipy=${SCIPY_VERSION} \
       conda-forge::blas=${OPENBLAS_VERSION}=openblas \


### PR DESCRIPTION
This PR adds `pytest-timeout` to our base Dockerfile so that we can prevent longrunning jobs.