### PR TITLE
Add pytest-timeout to centos

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -128,6 +128,7 @@ RUN conda create --no-default-packages -n gdf \
       dlpack=${DLPACK_VERSION} \
       pytest \
       pytest-cov \
+      pytest-timeout \
       scikit-learn=${SKLEARN_VERSION} \
       scipy=${SCIPY_VERSION} \
       conda-forge::blas=${OPENBLAS_VERSION}=openblas \

--- a/python3.5/Dockerfile
+++ b/python3.5/Dockerfile
@@ -111,6 +111,7 @@ RUN conda create --no-default-packages -n gdf \
       dlpack=${DLPACK_VERSION} \
       pytest \
       pytest-cov \
+      pytest-timeout \
       scikit-learn=${SKLEARN_VERSION} \
       scipy=${SCIPY_VERSION} \
       blas=1.1=openblas \

--- a/python3.5/Dockerfile.centos7
+++ b/python3.5/Dockerfile.centos7
@@ -123,6 +123,7 @@ RUN conda create --no-default-packages -n gdf \
       dlpack=${DLPACK_VERSION} \
       pytest \
       pytest-cov \
+      pytest-timeout \
       scikit-learn=${SKLEARN_VERSION} \
       scipy=${SCIPY_VERSION} \
       blas=1.1=openblas \


### PR DESCRIPTION
This PR adds `pytest-timeout` to centos. I forgot to add it in #73.