### PR TITLE
ENH Update Ubuntu gcc/g++ to 7.5.0 for 16.04 and 18.04

### DIFF
--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -46,6 +46,17 @@ channels: \n\
       && cat /conda/.condarc ; \
     fi
 
+# Install gcc7 - 7.5.0 to bring build stack in line with conda-forge
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && apt-get update \
+    && apt-get install gcc-7 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7 \
+    && update-alternatives --set gcc /usr/bin/gcc-7 \
+    && update-alternatives --set g++ /usr/bin/g++-7 \
+    && gcc --version \
+    && g++ --version
+
 # Update and add pkgs for gpuci builds
 RUN apt-get update -y --fix-missing \
     && apt-get -qq install apt-utils -y --no-install-recommends \


### PR DESCRIPTION
This is to bring the build env/toolchains into line with conda-forge's 7.5.0