### PR TITLE
[WIP] CUDA 11 Images

### DIFF
--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -13,11 +13,6 @@ DOCKER_FILE:
 
 CUDA_VER:
   - 11.0
-  - 10.2
-  - 10.1
-  - 10.0
-  - 9.2
-  - 9.0
 
 IMAGE_TYPE:
   - base

--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -3,6 +3,7 @@ BUILD_IMAGE:
 
 FROM_IMAGE:
   - nvidia/cuda
+  - gpuci/cuda
 
 IMAGE_NAME:
   - miniconda-cuda
@@ -11,6 +12,7 @@ DOCKER_FILE:
   - Dockerfile
 
 CUDA_VER:
+  - 11.0
   - 10.2
   - 10.1
   - 10.0
@@ -30,3 +32,15 @@ LINUX_VER:
 exclude:
   - CUDA_VER: 9.0
     LINUX_VER: ubuntu18.04
+  - CUDA_VER: 9.0
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 9.2
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 10.0
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 10.1
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 10.2
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 11.0
+    FROM_IMAGE: nvidia/cuda

--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -14,6 +14,7 @@ RAPIDS_VER:
   - 0.15
 
 CUDA_VER:
+  - 11.0
   - 10.2
   - 10.1
   - 10.0
@@ -32,17 +33,30 @@ DRIVER_VER:
   - 410
   - 418
   - 440
+  - 450
 
 exclude:
   - CUDA_VER: 10.0
     DRIVER_VER: 418
   - CUDA_VER: 10.0
     DRIVER_VER: 440
+  - CUDA_VER: 10.0
+    DRIVER_VER: 450
   - CUDA_VER: 10.1
     DRIVER_VER: 410
   - CUDA_VER: 10.1
     DRIVER_VER: 440
+  - CUDA_VER: 10.1
+    DRIVER_VER: 450
   - CUDA_VER: 10.2
     DRIVER_VER: 410
   - CUDA_VER: 10.2
     DRIVER_VER: 418
+  - CUDA_VER: 10.2
+    DRIVER_VER: 450
+  - CUDA_VER: 11.0
+    DRIVER_VER: 410
+  - CUDA_VER: 11.0
+    DRIVER_VER: 418
+  - CUDA_VER: 11.0
+    DRIVER_VER: 440

--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -15,9 +15,6 @@ RAPIDS_VER:
 
 CUDA_VER:
   - 11.0
-  - 10.2
-  - 10.1
-  - 10.0
 
 IMAGE_TYPE:
   - devel

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -19,6 +19,7 @@ RAPIDS_CHANNEL:
   - rapidsai-nightly
 
 CUDA_VER:
+  - 11.0
   - 10.2
   - 10.1
   - 10.0

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -20,9 +20,6 @@ RAPIDS_CHANNEL:
 
 CUDA_VER:
   - 11.0
-  - 10.2
-  - 10.1
-  - 10.0
 
 IMAGE_TYPE:
   - base


### PR DESCRIPTION
## Approach
Add CUDA 11 support to:
- [x] `miniconda-cuda`
- [x] `rapidsai`
- [x] `rapidsai-driver`

## Testing

### Successful builds
- [x] `miniconda-cuda` - https://gpuci.gpuopenanalytics.com/job/gpuci/job/docker/job/miniconda-cuda/61/
- [x] `rapidsai` - https://gpuci.gpuopenanalytics.com/job/gpuci/job/docker/job/rapidsai/78/
- [ ] `rapidsai-driver` - 

### Completed image tests 
- [ ] `miniconda-cuda`
- [ ] `rapidsai`
- [ ] `rapidsai-driver`