### PR TITLE
Update awscli to latest

### DIFF
--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -51,13 +51,18 @@ channels: \n\
 
 # Update and add pkgs for gpuci builds
 RUN yum install -y \
-      awscli \
       clang \
       numactl-devel \
       numactl-libs \
       screen \
       vim \
     && yum clean all
+
+# Install latest awscli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install \
+    && rm -rf ./aws ./awscliv2.zip
 
 # Add core tools to base env
 RUN source activate base \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -64,7 +64,6 @@ RUN apt-get update \
 RUN apt-get update -y --fix-missing \
     && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
-      awscli \
       jq \
       libnuma1 \
       libnuma-dev \
@@ -74,6 +73,12 @@ RUN apt-get update -y --fix-missing \
       zlib1g-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Install latest awscli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install \
+    && rm -rf ./aws ./awscliv2.zip
 
 # Add core tools to base env
 RUN source activate base \


### PR DESCRIPTION
This PR updates the `aws` cli to the latest version in anticipation of the benchmarking efforts.

These changes were tested on `dgx07` and seem to be working fine.