### PR TITLE
Revert "FIX Update to use conda install instead of curl"

### DIFF
--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -5,7 +5,9 @@ set -e
 export HOME=$WORKSPACE
 
 # Install gpuCI tools
-conda install -y -c gpuci gpuci-tools
+curl -s https://raw.githubusercontent.com/rapidsai/gpuci-tools/main/install.sh | bash
+source ~/.bashrc
+cd ~
 
 # Show env
 gpuci_logger "Exposing current environment..."


### PR DESCRIPTION
Duplicate of https://github.com/rapidsai/docker/pull/112

---

This PR reverts a commit on Thursday that has been breaking our builds.

The Jenkins agents that run Docker builds do not have `conda` installed and there are no plans to install `conda` at this time. Therefore `gpuci-tools` should be installed via `curl` to prevent builds from breaking.

