### PR TITLE
ENH Update conda-build version

### DIFF
--- a/miniconda-cuda-driver/Dockerfile
+++ b/miniconda-cuda-driver/Dockerfile
@@ -15,7 +15,7 @@ RUN source activate base \
     && gpuci_conda_retry install -k -y -c conda-forge \
       anaconda-client \
       codecov \
-      conda-build= \
+      conda-build =3.19.2 \
       conda-verify \
       ripgrep \
     && chmod -R ugo+w /opt/conda

--- a/miniconda-cuda-driver/Dockerfile
+++ b/miniconda-cuda-driver/Dockerfile
@@ -15,7 +15,7 @@ RUN source activate base \
     && gpuci_conda_retry install -k -y -c conda-forge \
       anaconda-client \
       codecov \
-      conda-build =3.19.2 \
+      conda-build=3.19.2 \
       conda-verify \
       ripgrep \
     && chmod -R ugo+w /opt/conda

--- a/miniconda-cuda-driver/Dockerfile
+++ b/miniconda-cuda-driver/Dockerfile
@@ -12,10 +12,10 @@ ARG DRIVER_VER="440"
 # Add core tools to base env
 RUN source activate base \
     && conda install -k -y --override-channels -c gpuci gpuci-tools \
-    && gpuci_retry conda install -k -y \
+    && gpuci_conda_retry install -k -y -c conda-forge \
       anaconda-client \
       codecov \
-      conda-build \
+      conda-build= \
       conda-verify \
       ripgrep \
     && chmod -R ugo+w /opt/conda


### PR DESCRIPTION
Use `conda-build` from `conda-forge` to get the latest version needed for package builds in integration and other repos. Version `3.19.2` is needed and not available in the `defaults` channel.