### PR TITLE
[REVIEW] Remove Leftover Mentions of Ccache

### DIFF
--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -10,7 +10,6 @@ ARG PYTHON_VER=3.6
 # Optional arguments
 ARG BUILD_STACK_VER=7.5.0
 ARG CENTOS7_GCC7_URL=https://gpuci.s3.us-east-2.amazonaws.com/builds/gcc7.tgz
-ARG CCACHE_VERSION=master
 
 # Capture argument used for FROM
 ARG CUDA_VER
@@ -105,31 +104,6 @@ RUN gpuci_retry conda install -y -n rapids --freeze-installed \
 RUN gpuci_retry wget --quiet ${CENTOS7_GCC7_URL} -O /gcc7.tgz \
     && tar xzvf /gcc7.tgz \
     && rm -f /gcc7.tgz
-
-# Build ccache from source and create symlinks
-#RUN curl -s -L https://github.com/ccache/ccache/archive/master.zip -o /tmp/ccache-${CCACHE_VERSION}.zip \
-#    && unzip -d /tmp/ccache-${CCACHE_VERSION} /tmp/ccache-${CCACHE_VERSION}.zip \
-#    && cd /tmp/ccache-${CCACHE_VERSION}/ccache-master \
-#    && ./autogen.sh \
-#    && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet \
-#    && make install -j \
-#    && cd / \
-#    && rm -rf /tmp/ccache-${CCACHE_VERSION}* \
-#    && mkdir -p /ccache
-
-# Setup ccache env vars
-#ENV CCACHE_NOHASHDIR=
-#ENV CCACHE_DIR="/ccache"
-#ENV CCACHE_COMPILERCHECK="%compiler% --version"
-
-# Uncomment these env vars to force ccache to be enabled by default
-#ENV CC="/usr/local/bin/gcc"
-#ENV CXX="/usr/local/bin/g++"
-#ENV NVCC="/usr/local/bin/nvcc"
-#ENV CUDAHOSTCXX="/usr/local/bin/g++"
-#RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-#    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-#    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
 
 # Clean up pkgs to reduce image size and chmod for all users
 RUN conda clean -afy \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -10,7 +10,6 @@ ARG PYTHON_VER=3.6
 
 # Optional arguments
 ARG BUILD_STACK_VER=7.5.0
-ARG CCACHE_VERSION=master
 
 # Capture argument used for FROM
 ARG CUDA_VER
@@ -116,31 +115,6 @@ RUN gpuci_retry conda install -y -n rapids --freeze-installed \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}
-
-# Build ccache from source and create symlinks
-#RUN curl -s -L https://github.com/ccache/ccache/archive/master.zip -o /tmp/ccache-${CCACHE_VERSION}.zip \
-#    && unzip -d /tmp/ccache-${CCACHE_VERSION} /tmp/ccache-${CCACHE_VERSION}.zip \
-#    && cd /tmp/ccache-${CCACHE_VERSION}/ccache-master \
-#    && ./autogen.sh \
-#    && ./configure --disable-man --with-libb2-from-internet --with-libzstd-from-internet\
-#    && make install -j \
-#    && cd / \
-#    && rm -rf /tmp/ccache-${CCACHE_VERSION}* \
-#    && mkdir -p /ccache
-
-# Setup ccache env vars
-#ENV CCACHE_NOHASHDIR=
-#ENV CCACHE_DIR="/ccache"
-#ENV CCACHE_COMPILERCHECK="%compiler% --version"
-
-# Uncomment these env vars to force ccache to be enabled by default
-#ENV CC="/usr/local/bin/gcc"
-#ENV CXX="/usr/local/bin/g++"
-#ENV NVCC="/usr/local/bin/nvcc"
-#ENV CUDAHOSTCXX="/usr/local/bin/g++"
-#RUN ln -s "$(which ccache)" "/usr/local/bin/gcc" \
-#    && ln -s "$(which ccache)" "/usr/local/bin/g++" \
-#    && ln -s "$(which ccache)" "/usr/local/bin/nvcc"
 
 # Clean up pkgs to reduce image size and chmod for all users
 RUN conda clean -afy \


### PR DESCRIPTION
There are a few mentions of ccache that were leftover from when ccache used to be built in the `gpuci/rapidsai` images. This PR cleans them up as ccache is now being built from source in the `devel` images.