### PR TITLE
Update jq installation

### DIFF
--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -57,9 +57,13 @@ RUN yum install -y \
       vim \
     && yum clean all
 
+ARG JQPATH=/usr/local/bin/jq
+RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O ${JQPATH} \
+    && chmod +x $JQPATH
+
 # Install latest awscli
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-    && unzip awscliv2.zip \
+    && unzip -q awscliv2.zip \
     && ./aws/install \
     && rm -rf ./aws ./awscliv2.zip
 

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -63,7 +63,6 @@ RUN apt-get update \
 RUN apt-get update -y --fix-missing \
     && apt-get -qq install apt-utils -y --no-install-recommends \
     && apt-get install -y \
-      jq \
       libnuma1 \
       libnuma-dev \
       screen \
@@ -73,9 +72,14 @@ RUN apt-get update -y --fix-missing \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Install latest jq
+ARG JQPATH=/usr/local/bin/jq
+RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O ${JQPATH} \
+    && chmod +x $JQPATH
+
 # Install latest awscli
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-    && unzip awscliv2.zip \
+    && unzip -q awscliv2.zip \
     && ./aws/install \
     && rm -rf ./aws ./awscliv2.zip
 


### PR DESCRIPTION
This PR installs `jq` directly from source (https://stedolan.github.io/jq/download/) on both rapidsai `devel` images.

These changes were tested and confirmed working locally.

Additionally, it adds a `-q` (quiet) flag to the `unzip` command so it doesn't output so much during Docker builds.