### PR TITLE
[skip ci] Update master references for main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ into three categories:
 
 ### Your first issue
 
-1. Read the project's [README.md](https://github.com/rapidsai/gpuci-build-environment/blob/master/README.md)
+1. Read the project's [README.md](https://github.com/rapidsai/gpuci-build-environment/blob/main/README.md)
     to learn how to setup the development environment
 2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/rapidsai/gpuci-build-environment/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
     or [help wanted](https://github.com/rapidsai/gpuci-build-environment/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels


### PR DESCRIPTION
This PR changes any 'master' references to 'main' in markdown files throughout the repo as part of the new 'master' to 'main' branch migration.