### PR TITLE
ENH Add CUDA 11.0 to miniconda-cuda/-driver & PR testing

### DIFF
--- a/ci/axis/miniconda-cuda-driver.yml
+++ b/ci/axis/miniconda-cuda-driver.yml
@@ -11,6 +11,7 @@ DOCKER_FILE:
   - Dockerfile
 
 CUDA_VER:
+  - 11.0
   - 10.2
   - 10.1
   - 10.0
@@ -25,17 +26,30 @@ DRIVER_VER:
   - 410
   - 418
   - 440
+  - 450
 
 exclude:
   - CUDA_VER: 10.0
     DRIVER_VER: 418
   - CUDA_VER: 10.0
     DRIVER_VER: 440
+  - CUDA_VER: 10.0
+    DRIVER_VER: 450
   - CUDA_VER: 10.1
     DRIVER_VER: 410
   - CUDA_VER: 10.1
     DRIVER_VER: 440
+  - CUDA_VER: 10.1
+    DRIVER_VER: 450
   - CUDA_VER: 10.2
     DRIVER_VER: 410
   - CUDA_VER: 10.2
     DRIVER_VER: 418
+  - CUDA_VER: 10.2
+    DRIVER_VER: 450
+  - CUDA_VER: 11.0
+    DRIVER_VER: 410
+  - CUDA_VER: 11.0
+    DRIVER_VER: 418
+  - CUDA_VER: 11.0
+    DRIVER_VER: 440

--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -12,6 +12,7 @@ DOCKER_FILE:
   - Dockerfile
 
 CUDA_VER:
+  - 11.0
   - 10.2
   - 10.1
   - 10.0
@@ -40,4 +41,6 @@ exclude:
   - CUDA_VER: 10.1
     FROM_IMAGE: gpuci/cuda
   - CUDA_VER: 10.2
+    FROM_IMAGE: nvidia/cuda
+  - CUDA_VER: 11.0
     FROM_IMAGE: nvidia/cuda

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -20,6 +20,21 @@ echo $DH_TOKEN | docker login --username $DH_USER --password-stdin &> /dev/null
 # Get build info ready
 gpuci_logger "Preparing build args and info..."
 BUILD_TAG="${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}"
+# Check if PR build and modify BUILD_IMAGE and BUILD_TAG
+if [ ! -z "$PR_ID" ] ; then
+  echo "PR_ID is set to '$PR_ID', updating BUILD_IMAGE..."
+  BUILD_REPO=`echo $BUILD_IMAGE | tr '/' ' ' | awk '{ print $2 }'`
+  BUILD_IMAGE="gpucitesting/${BUILD_REPO}-pr${PR_ID}"
+  # Check if FROM_IMAGE to see if it is a root build
+  if [ "$FROM_IMAGE" == "gpuci/cuda" -o "$FROM_IMAGE" == "nvidia/cuda" ] ; then
+    echo ">> No need to update FROM_IMAGE, using external image..."
+  else
+    echo ">> Need to update FROM_IMAGE to use PR's version for testing..."
+    FROM_REPO=`echo $FROM_IMAGE | tr '/' ' ' | awk '{ print $2 }'`
+    FROM_IMAGE="gpucitesting/${FROM_REPO}-pr${PR_ID}"
+  fi
+fi
+# Setup initial BUILD_ARGS
 BUILD_ARGS="--squash --build-arg FROM_IMAGE=$FROM_IMAGE --build-arg CUDA_VER=$CUDA_VER --build-arg IMAGE_TYPE=$IMAGE_TYPE --build-arg LINUX_VER=$LINUX_VER"
 # Check if PYTHON_VER is set
 if [ -z "$PYTHON_VER" ] ; then

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -18,22 +18,22 @@ gpuci_logger "Logging into Docker..."
 echo $DH_TOKEN | docker login --username $DH_USER --password-stdin &> /dev/null
 
 # Get build info ready
-gpuci_logger "Preparing to build..."
+gpuci_logger "Preparing build args and info..."
 BUILD_TAG="${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}"
 BUILD_ARGS="--squash --build-arg FROM_IMAGE=$FROM_IMAGE --build-arg CUDA_VER=$CUDA_VER --build-arg IMAGE_TYPE=$IMAGE_TYPE --build-arg LINUX_VER=$LINUX_VER"
 # Check if PYTHON_VER is set
 if [ -z "$PYTHON_VER" ] ; then
-  gpuci_logger "PYTHON_VER is not set, skipping..."
+  echo "PYTHON_VER is not set, skipping..."
 else
-  gpuci_logger "PYTHON_VER is set to '$PYTHON_VER', adding to build args/tag..."
+  echo "PYTHON_VER is set to '$PYTHON_VER', adding to build args/tag..."
   BUILD_ARGS="${BUILD_ARGS} --build-arg PYTHON_VER=${PYTHON_VER}"
   BUILD_TAG="${BUILD_TAG}-py${PYTHON_VER}"
 fi
 # Check if DRIVER_VER is set
 if [ -z "$DRIVER_VER" ] ; then
-  gpuci_logger "DRIVER_VER is not set, skipping..."
+  echo "DRIVER_VER is not set, skipping..."
 else
-  gpuci_logger "DRIVER_VER is set to '$DRIVER_VER', adding to build args..."
+  echo "DRIVER_VER is set to '$DRIVER_VER', adding to build args..."
   BUILD_ARGS="${BUILD_ARGS} --build-arg DRIVER_VER=${DRIVER_VER}"
 fi
 # Check if RAPIDS_VER is set

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -15,7 +15,7 @@ env
 
 # Login to docker
 gpuci_logger "Logging into Docker..."
-echo $DH_TOKEN | docker login --username $DH_USER --password-stdin
+echo $DH_TOKEN | docker login --username $DH_USER --password-stdin &> /dev/null
 
 # Get build info ready
 gpuci_logger "Preparing to build..."


### PR DESCRIPTION
Add CUDA 11.0 versions for `miniconda-cuda` & `miniconda-cuda-driver` to support building packages needed for bringup.

Also add PR testing back to this repo with script changes to support the new jobs & PR pipeline: https://gpuci.gpuopenanalytics.com/job/gpuci/job/gpuci-build-environment/