### PR TITLE
[REVIEW] Update CI scripts to remove references to master [skip ci] 

### DIFF
--- a/templates/ci/checks/changelog.sh
+++ b/templates/ci/checks/changelog.sh
@@ -7,8 +7,8 @@
 #########################
 ##*
 
-# Checkout master for comparison
-git checkout --quiet master
+# Checkout main for comparison
+git checkout --quiet main
 
 # Switch back to tip of PR branch
 git checkout --quiet current-pr-branch
@@ -17,7 +17,7 @@ git checkout --quiet current-pr-branch
 set +e
 
 # Get list of modified files between matster and PR branch
-CHANGELOG=`git diff --name-only master...current-pr-branch | grep CHANGELOG.md`
+CHANGELOG=`git diff --name-only main...current-pr-branch | grep CHANGELOG.md`
 # Check if CHANGELOG has PR ID
 PRNUM=`cat CHANGELOG.md | grep "$PR_ID"`
 RETVAL=0

--- a/templates/ci/cpu/upload_anaconda.sh
+++ b/templates/ci/cpu/upload_anaconda.sh
@@ -10,11 +10,9 @@ export |<package>|_FILE=`conda build conda/recipes/|<package>| --output`
 export |<package>|_FILE=`conda build conda/recipes/|<package>| --python=$PYTHON --output`
 ##*
 
-SOURCE_BRANCH=master
 CUDA_REL=${CUDA_VERSION%.*}
 
-# Restrict uploads to master branch
-if [ ${GIT_BRANCH} != ${SOURCE_BRANCH} ]; then
+if [ ${BUILD_MODE} != "branch" ]; then
   echo "Skipping upload"
   return 0
 fi


### PR DESCRIPTION
This PR removes unecessary references to master or updates references to the new main branch in CI scripts and other OPS-owned files.