### PR TITLE
BUG Fix nvidia/cuda images that do not set CUDA_VERSION

### DIFF
--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -19,6 +19,16 @@ CUDA_VER:
   - 9.2
   - 9.0
 
+# CUDA_VERSION is not defined for CUDA 11 images - this defines it in this image
+## so it can be used in all images within gpuCI
+FULL_CUDA_VERSION:
+  - 11.0.2
+  - 10.2.89
+  - 10.1.243
+  - 10.0.130
+  - 9.2.148
+  - 9.0.176
+
 IMAGE_TYPE:
   - base
   - runtime

--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -33,17 +33,17 @@ LINUX_VER:
   - centos7
 
 exclude:
-  - CUDA_VER: 9.0
+  - CUDA_VER: 9.0.176
     LINUX_VER: ubuntu18.04
-  - CUDA_VER: 9.0
+  - CUDA_VER: 9.0.176
     FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 9.2
+  - CUDA_VER: 9.2.148
     FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 10.0
+  - CUDA_VER: 10.0.130
     FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 10.1
+  - CUDA_VER: 10.1.243
     FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 10.2
+  - CUDA_VER: 10.2.89
     FROM_IMAGE: nvidia/cuda
-  - CUDA_VER: 11.0
+  - CUDA_VER: 11.0.2
     FROM_IMAGE: nvidia/cuda

--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -11,17 +11,10 @@ IMAGE_NAME:
 DOCKER_FILE:
   - Dockerfile
 
-CUDA_VER:
-  - 11.0
-  - 10.2
-  - 10.1
-  - 10.0
-  - 9.2
-  - 9.0
-
 # CUDA_VERSION is not defined for CUDA 11 images - this defines it in this image
-## so it can be used in all images within gpuCI
-FULL_CUDA_VERSION:
+#   so it can be used in all images within gpuCI; to make parsing easier we add
+#   it to the existing CUDA_VER var and remove the patch version in run script
+CUDA_VER:
   - 11.0.2
   - 10.2.89
   - 10.1.243

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -5,6 +5,7 @@ ARG LINUX_VER=ubuntu18.04
 FROM ${FROM_IMAGE}:${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}
 
 # Pull argument from build args
+ARG FULL_CUDA_VER
 ARG LINUX_VER
 
 # Define versions and download locations
@@ -19,7 +20,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Set CUDA_VERSION as in some 'nvidia/cuda' images this is not set
 ## A lot of scripts and conda recipes depend on this env var
-ENV CUDA_VERSION=${FULL_CUDA_VERSION}
+ENV CUDA_VERSION=${FULL_CUDA_VER}
 
 # Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -17,6 +17,10 @@ ARG TINI_URL=https://github.com/krallin/tini/releases/download/${TINI_VER}/tini
 ENV PATH=/opt/conda/bin:${PATH}
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Set CUDA_VERSION as in some 'nvidia/cuda' images this is not set
+## A lot of scripts and conda recipes depend on this env var
+ENV CUDA_VERSION=${FULL_CUDA_VERSION}
+
 # Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
CUDA 11 images no longer set  which is relied upon for our conda recipes and various other scripts. This explicitly sets  for all  images and should effectively patch all images preventing them from encountering this bug