### PR TITLE
ENH Remove `nomkl` from `rapids` conda env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,16 +62,16 @@ Here is an example on extending the image:
 
 ```Dockerfile
 ARG FROM_IMAGE=gpuci/miniconda-cuda
-ARG CUDA_VERSION=9.2
+ARG CUDA_VERSION=10.1
 ARG CUDA_VER=${CUDA_VERSION}
 ARG CUDA_TYPE=devel
-ARG LINUX_VERSION=ubuntu16.04
+ARG LINUX_VERSION=ubuntu18.04
 FROM ${FROM_IMAGE}:${CUDA_VERSION}-${CUDA_TYPE}-${LINUX_VERSION}
 
 # Define arguments
 ARG CUDA_VER
-ARG PYTHON_VERSION=3.6
-ARG LIB_NG_VERSION=7.3.0
+ARG PYTHON_VERSION=3.7
+ARG LIB_NG_VERSION=7.5.0
 
 # Set environment
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
@@ -84,7 +84,7 @@ RUN source activate base \
       -c conda-forge \
       -c defaults \
       cudatoolkit=${CUDA_VER} \
-      conda-forge::blas=1.1=openblas \
+      conda-forge::blas \
       libgcc-ng=${LIB_NG_VERSION} \
       libstdcxx-ng=${LIB_NG_VERSION} \
       python=${PYTHON_VERSION} \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,6 @@ RUN source activate base \
       -c nvidia \
       -c conda-forge \
       -c defaults \
-      nomkl \
       cudatoolkit=${CUDA_VER} \
       conda-forge::blas=1.1=openblas \
       libgcc-ng=${LIB_NG_VERSION} \

--- a/legacy/miniconda-cuda-rapidsenv/Dockerfile
+++ b/legacy/miniconda-cuda-rapidsenv/Dockerfile
@@ -24,7 +24,6 @@ RUN source activate base \
       -c nvidia \
       -c conda-forge \
       -c defaults \
-      nomkl \
       cudatoolkit=${CUDA_VER} \
       conda-forge::blas=2.14=openblas \
       git \

--- a/legacy/miniconda-cuda-rapidsenv/Dockerfile.centos7
+++ b/legacy/miniconda-cuda-rapidsenv/Dockerfile.centos7
@@ -24,7 +24,6 @@ RUN source activate base \
       -c nvidia \
       -c conda-forge \
       -c defaults \
-      nomkl \
       cudatoolkit=${CUDA_VER} \
       conda-forge::blas=2.14=openblas \
       git \

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -47,7 +47,6 @@ RUN source activate base \
       -c nvidia \
       -c conda-forge \
       -c defaults \
-      nomkl \
       cudatoolkit=${CUDA_VER} \
       git \
       libgcc-ng=${BUILD_STACK_VER} \

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -80,7 +80,6 @@ RUN source activate base \
       -c nvidia \
       -c conda-forge \
       -c defaults \
-      nomkl \
       cudatoolkit=${CUDA_VER} \
       git \
       libgcc-ng=${BUILD_STACK_VER} \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -96,7 +96,6 @@ RUN source activate base \
       -c nvidia \
       -c conda-forge \
       -c defaults \
-      nomkl \
       cudatoolkit=${CUDA_VER} \
       git \
       libgcc-ng=${BUILD_STACK_VER} \


### PR DESCRIPTION
From updates in conda-forge and changes made in rapidsai/integration#91 we no longer need to rely on installing `nomkl` to ensure that mkl is not installed.

This frees up users and libraries to install `pytorch` and `mkl` as needed.