### PR TITLE
FIX Add 0.16 RAPIDS to nightly axis

### DIFF
--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -12,6 +12,7 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - 0.15
+  - 0.16
 
 CUDA_VER:
   - 11.0

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -14,6 +14,7 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - 0.15
+  - 0.16
 
 RAPIDS_CHANNEL:
   - rapidsai-nightly


### PR DESCRIPTION
This enables image builds for RAPDIS v0.16 as burndown started yesterday.