### PR TITLE
ENH Add Gpuci-Tools to Rapid Env Activate

### DIFF
--- a/legacy/miniconda-cuda-rapidsenv/Dockerfile.centos7
+++ b/legacy/miniconda-cuda-rapidsenv/Dockerfile.centos7
@@ -28,6 +28,7 @@ RUN source activate base \
       cudatoolkit=${CUDA_VER} \
       conda-forge::blas=2.14=openblas \
       git \
+      gpuci-tools \
       libgcc-ng=${LIB_NG_VERSION} \
       libstdcxx-ng=${LIB_NG_VERSION} \
       python=${PYTHON_VERSION} \

--- a/legacy/miniconda-cuda-rapidsenv/Dockerfile.centos7
+++ b/legacy/miniconda-cuda-rapidsenv/Dockerfile.centos7
@@ -27,7 +27,6 @@ RUN source activate base \
       cudatoolkit=${CUDA_VER} \
       conda-forge::blas=2.14=openblas \
       git \
-      gpuci-tools \
       libgcc-ng=${LIB_NG_VERSION} \
       libstdcxx-ng=${LIB_NG_VERSION} \
       python=${PYTHON_VERSION} \

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -52,6 +52,7 @@ RUN source activate base \
       nomkl \
       cudatoolkit=${CUDA_VER} \
       git \
+      gpuci-tools \
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -50,7 +50,6 @@ RUN source activate base \
       -c conda-forge \
       -c defaults \
       -c gpuci \
-      nomkl \
       cudatoolkit=${CUDA_VER} \
       git \
       gpuci-tools \

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -49,6 +49,7 @@ RUN source activate base \
       -c nvidia \
       -c conda-forge \
       -c defaults \
+      -c gpuci \
       nomkl \
       cudatoolkit=${CUDA_VER} \
       git \

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -83,7 +83,6 @@ RUN source activate base \
       -c conda-forge \
       -c defaults \
       -c gpuci \
-      nomkl \
       cudatoolkit=${CUDA_VER} \
       git \
       gpuci-tools \

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -85,6 +85,7 @@ RUN source activate base \
       nomkl \
       cudatoolkit=${CUDA_VER} \
       git \
+      gpuci-tools \
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -82,6 +82,7 @@ RUN source activate base \
       -c nvidia \
       -c conda-forge \
       -c defaults \
+      -c gpuci \
       nomkl \
       cudatoolkit=${CUDA_VER} \
       git \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -101,6 +101,7 @@ RUN source activate base \
       nomkl \
       cudatoolkit=${CUDA_VER} \
       git \
+      gpuci-tools \
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -99,7 +99,6 @@ RUN source activate base \
       -c conda-forge \
       -c defaults \
       -c gpuci \
-      nomkl \
       cudatoolkit=${CUDA_VER} \
       git \
       gpuci-tools \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -98,6 +98,7 @@ RUN source activate base \
       -c nvidia \
       -c conda-forge \
       -c defaults \
+      -c gpuci \
       nomkl \
       cudatoolkit=${CUDA_VER} \
       git \


### PR DESCRIPTION
Add `gpuci-tools` to be installed when activating rapids in images. Allows for easy access to tools such as `gpuci logger` functionality.

Has been tested by running `gpuci_logger` in the resultant `gpuci/rapidsai` image after removing `/opt/conda/bin` from the `PATH`.