### PR TITLE
ENH Change conda to gpuci_conda_retry

### DIFF
--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -45,7 +45,7 @@ channels: \n\
 # Create rapids conda env and make default
 RUN source activate base \
     && conda install -y gpuci-tools \
-    && conda create --no-default-packages --override-channels -n rapids \
+    && gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c defaults \


### PR DESCRIPTION
Replaces `conda create` with `gpuci_conda_retry create`

This may be changed later on based on https://github.com/rapidsai/gpuci-tools/issues/6