### PR TITLE
ENH Use nvidia/cuda for CUDA 10.2 & 11.0 Update 1

### DIFF
--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -3,7 +3,7 @@ BUILD_IMAGE:
 
 FROM_IMAGE:
   - nvidia/cuda
-  - gpuci/cuda
+#  - gpuci/cuda
 
 IMAGE_NAME:
   - miniconda-cuda
@@ -15,7 +15,7 @@ DOCKER_FILE:
 #   so it can be used in all images within gpuCI; to make parsing easier we add
 #   it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
-  - 11.0.194
+  - 11.0.221
   - 10.2.89
   - 10.1.243
   - 10.0.130
@@ -35,15 +35,17 @@ LINUX_VER:
 exclude:
   - CUDA_VER: 9.0.176
     LINUX_VER: ubuntu18.04
-  - CUDA_VER: 9.0.176
-    FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 9.2.148
-    FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 10.0.130
-    FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 10.1.243
-    FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 10.2.89
-    FROM_IMAGE: nvidia/cuda
-  - CUDA_VER: 11.0.194
-    FROM_IMAGE: nvidia/cuda
+# Uncomment below and `- gpuci/cuda` above to build using gpuCI CUDA images
+# NOTE: gpuci/cuda:11.0* is 11.0.194 and would need CUDA_VER to change on revert
+#  - CUDA_VER: 9.0.176
+#    FROM_IMAGE: gpuci/cuda
+#  - CUDA_VER: 9.2.148
+#    FROM_IMAGE: gpuci/cuda
+#  - CUDA_VER: 10.0.130
+#    FROM_IMAGE: gpuci/cuda
+#  - CUDA_VER: 10.1.243
+#    FROM_IMAGE: gpuci/cuda
+#  - CUDA_VER: 10.2.89
+#    FROM_IMAGE: nvidia/cuda
+#  - CUDA_VER: 11.0.194
+#    FROM_IMAGE: nvidia/cuda


### PR DESCRIPTION
Disable builds from using `gpuci/cuda` that held our archived versions of CUDA 10.2 and 11.0 GA. Instead use the recently updated `nvidia/cuda` images that includes CUDA 11.0 Update 1.

Leaving the exclusions and `gpuci/cuda` options in but commented out so if we need to revert we can quickly.