### PR TITLE
ENH Disable 0.15 builds in 0.16 branch

### DIFF
--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - Dockerfile
 
 RAPIDS_VER:
-  - 0.15
   - 0.16
 
 CUDA_VER:

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -13,7 +13,6 @@ DOCKER_FILE:
   - devel-centos7.Dockerfile
 
 RAPIDS_VER:
-  - 0.15
   - 0.16
 
 RAPIDS_CHANNEL:
@@ -39,10 +38,6 @@ PYTHON_VER:
   - 3.8
 
 exclude:
-  - RAPIDS_VER: 0.14
-    RAPIDS_CHANNEL: rapidsai-nightly
-  - RAPIDS_VER: 0.15
-    RAPIDS_CHANNEL: rapidsai
   - IMAGE_TYPE: base
     DOCKER_FILE: devel.Dockerfile
   - IMAGE_TYPE: base


### PR DESCRIPTION
With 0.15 released we no longer need to build 0.15 images