### PR TITLE
Pin setuptools to < 50

### DIFF
--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -56,6 +56,7 @@ RUN source activate base \
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
+      "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
 # Create symlink for old scripts expecting `gdf` conda env

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -89,6 +89,7 @@ RUN source activate base \
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
+      "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
 # Create symlink for old scripts expecting `gdf` conda env

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -105,6 +105,7 @@ RUN source activate base \
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
+      "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
 # Create symlink for old scripts expecting `gdf` conda env


### PR DESCRIPTION
As indicated by @kkraus14 in Slack, the new version `50` of `setuptools` broke our `devel` builds. This PR pins the version of `setuptools` to < 50 to get our builds working again.

See `devel` build log:

https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-devel/77/BUILD_IMAGE=rapidsai%2Frapidsai-dev-nightly,CUDA_VER=10.1,FROM_IMAGE=gpuci%2Frapidsai,IMAGE_TYPE=devel,LINUX_VER=ubuntu18.04,PYTHON_VER=3.7,RAPIDS_CHANNEL=rapidsai-nightly,RAPIDS_VER=0.16/console