### PR TITLE
Disable cuda repo in CentOS images

### DIFF
--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -37,7 +37,8 @@ RUN if [ "${LINUX_VER}" != "centos7" ] ; then \
 
 # Update and add pkgs for centOS
 RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
-      yum -y update --disablerepo=cuda \
+      yum-config-manager --disable cuda \
+      yum -y update \
       && yum remove -y bind-license \
       && yum -y install wget bzip2 ca-certificates curl which patch unzip make automake autoconf git \
       && yum clean all ; \


### PR DESCRIPTION
This is a continuation of #124, where updating the `cuda` yum repo was causing incompatible versions of `cublas` to be installed and breaking our images. The solution was to disable the `cuda` repo during `yum update` so the incompatible packages were not installed. However, that solution did not prevent child images (i.e. rapidsai/docker images) from installing the incompatible packages when `yum update` is run.

This PR addresses that by disabling the `cuda` repo for CentOS images entirely, which should propagate to child images.