### PR TITLE
Fix cublas include error

### DIFF
--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -22,6 +22,7 @@ ENV CUDAHOSTCXX=${GCC7_DIR}/bin/g++
 ENV CUDA_HOME=/usr/local/cuda
 ENV LD_LIBRARY_PATH=${GCC7_DIR}/lib64:$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
 ENV PATH=${GCC7_DIR}/bin:$PATH
+ENV CPLUS_INCLUDE_PATH="/usr/local/cuda-10.2/include"
 
 # Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
As seen in the screenshot below, `nvidia/cuda:10.1-devel-centos7` images have the `cublas_v2.h` files in the `/usr/local/cuda-10.2/include` folder instead of `/usr/local/cuda-10.1/include`. This causes "missing cublas_v2.h" errors in our `devel` build Jenkins jobs [as shown here](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-devel/120/).

After reporting this to Jesus Alvarez, maintainer of the `nvidia/cuda` images, he mentioned that this was intentional and pointed me to the [explanation shown here](https://gitlab.com/nvidia/container-images/cuda/-/issues/88#note_411485001).

As a result, our images need to be patched with the changes in this PR to get the `centos-devel` builds working again.

![image](https://user-images.githubusercontent.com/7400326/92971238-1aa70000-f44e-11ea-9079-552a8e531847.png)

