### PR TITLE
FIX Update ENV vars for UTF-8

### DIFF
--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -15,7 +15,9 @@ ARG MINICONDA_URL=http://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VER}-Lin
 ARG TINI_URL=https://github.com/krallin/tini/releases/download/${TINI_VER}/tini
 
 # Set environment
-ENV PATH=/opt/conda/bin:${PATH}
+ENV CONDA_DIR=/opt/conda
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH=${CONDA_DIR}/bin:${PATH}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set CUDA_VERSION as in some 'nvidia/cuda' images this is not set


### PR DESCRIPTION
This is to match images used by `conda-forge` and to fix the observed errors with builds based on conflicting types.

cc @raydouglass @kkraus14

### Sources
- [condaforge/miniforge3](https://github.com/conda-forge/docker-images/blob/master/miniforge3/Dockerfile#L7) uses this (which is this PR)
```
LANG=C.UTF-8 LC_ALL=C.UTF-8
``` 
- [condaforge/linux-anvil-cos7-x86_64](https://github.com/conda-forge/docker-images/blob/master/linux-anvil-cos7-x86_64/Dockerfile#L6) & `linux-anvil-cuda` both use, but is **not** in this PR
```
LANG en_US.UTF-8
```