### PR TITLE
FIX Change `LANG` and `LC_ALL` to `en_US.UTF-8`

### DIFF
--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -16,7 +16,7 @@ ARG TINI_URL=https://github.com/krallin/tini/releases/download/${TINI_VER}/tini
 
 # Set environment
 ENV CONDA_DIR=/opt/conda
-ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 ENV PATH=${CONDA_DIR}/bin:${PATH}
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Fixes #130 where we set `LANG` and `LC_ALL` to `C.UTF-8`. This works for Ubuntu images, but fails on CentOS 7 images as it does not have the locale installed. It is not easy to install on CentOS 7 (pkgs exist for CentOS 8). Making this change brings us inline with the containers used by conda-forge which also use `en_US.UTF-8`

cc @raydouglass @kkraus14 