### PR TITLE
FIX Generate locales on Ubuntu

### DIFF
--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -81,6 +81,8 @@ RUN wget --quiet ${MINICONDA_URL} -O /miniconda.sh \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
     && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
     && echo "conda activate base" >> ~/.bashrc \
+    && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/skel/.bashrc \
+    && echo "conda activate base" >> /etc/skel/.bashrc \
     && chmod -R ugo+w /opt/conda \
     && ln -s /opt/conda /conda
 

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -30,7 +30,17 @@ SHELL ["/bin/bash", "-c"]
 # Update and add pkgs for Ubuntu
 RUN if [ "${LINUX_VER}" != "centos7" ] ; then \
       apt-get update \
-      && apt-get install -y wget bzip2 ca-certificates curl tzdata patch unzip automake autoconf git \
+      && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        bzip2 \
+        ca-certificates \
+        curl \
+        git \
+        patch \
+        tzdata \
+        unzip \
+        wget \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/* ; \
     else \

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -16,7 +16,7 @@ ARG TINI_URL=https://github.com/krallin/tini/releases/download/${TINI_VER}/tini
 
 # Set environment
 ENV CONDA_DIR=/opt/conda
-ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LANGUAGE=en_US:en
 ENV PATH=${CONDA_DIR}/bin:${PATH}
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -27,7 +27,7 @@ ENV CUDA_VERSION=${FULL_CUDA_VER}
 # Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]
 
-# Update and add pkgs for Ubuntu
+# Update and add pkgs for Ubuntu, also generate locales for 'en_US.UTF-8'
 RUN if [ "${LINUX_VER}" != "centos7" ] ; then \
       apt-get update \
       && apt-get install -y --no-install-recommends \
@@ -37,12 +37,15 @@ RUN if [ "${LINUX_VER}" != "centos7" ] ; then \
         ca-certificates \
         curl \
         git \
+        locales \
         patch \
         tzdata \
         unzip \
         wget \
       && apt-get clean \
-      && rm -rf /var/lib/apt/lists/* ; \
+      && rm -rf /var/lib/apt/lists/* \
+      && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+      && locale-gen ; \
     else \
       echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'ubuntu16.04' or 'ubuntu18.04'\n\n"; \
     fi

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -52,7 +52,18 @@ RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
       yum-config-manager --disable cuda \
       && yum -y update \
       && yum remove -y bind-license \
-      && yum -y install wget bzip2 ca-certificates curl which patch unzip make automake autoconf git \
+      && yum -y install \
+        autoconf \
+        automake \
+        bzip2 \
+        ca-certificates \
+        curl \
+        git \
+        make \
+        patch \
+        unzip \
+        wget \
+        which \
       && yum clean all ; \
     else \
       echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'centos7'\n\n"; \

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -67,9 +67,9 @@ RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
 RUN if [ "${IMAGE_TYPE}" == "runtime" ] ; then \
-      gpuci_retry conda install -y -n rapids --freeze-installed \
+      gpuci_conda_retry install -y -n rapids --freeze-installed \
         rapids-notebook-env=${RAPIDS_VER} \
-      && conda remove -y -n rapids --force-remove \
+      && gpuci_conda_retry remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER} ; \
     else \
       echo -e "\n\n>>>> SKIPPING: IMAGE_TYPE is not 'runtime'\n\n"; \

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -72,13 +72,13 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 # Add core tools to base env
 RUN source activate base \
     && conda install -y gpuci-tools \
-    && gpuci_retry conda install -y \
+    && gpuci_conda_retry install -y \
       anaconda-client \
       codecov
 
 # Create `rapids` conda env and make default
 RUN source activate base \
-    && gpuci_retry conda create --no-default-packages --override-channels -n rapids \
+    && gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c defaults \
@@ -99,11 +99,12 @@ RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN gpuci_retry conda install -y -n rapids --freeze-installed \
+RUN source activate base \
+    && gpuci_conda_retry install -y -n rapids --freeze-installed \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \
-    && conda remove -y -n rapids --force-remove \
+    && gpuci_conda_retry remove -y -n rapids --force-remove \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -89,13 +89,13 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 # Add core tools to base env
 RUN source activate base \
     && conda install -y gpuci-tools \
-    && gpuci_retry conda install -y \
+    && gpuci_conda_retry install -y \
       anaconda-client \
       codecov
 
 # Create `rapids` conda env and make default
 RUN source activate base \
-    && gpuci_retry conda create --no-default-packages --override-channels -n rapids \
+    && gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c defaults \
@@ -116,11 +116,12 @@ RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN gpuci_retry conda install -y -n rapids --freeze-installed \
+RUN source activate base \
+    && gpuci_conda_retry install -y -n rapids --freeze-installed \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \
-    && conda remove -y -n rapids --force-remove \
+    && gpuci_conda_retry remove -y -n rapids --force-remove \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}


### PR DESCRIPTION
Install `locales` and generate `en_US.UTF-8` for Ubuntu images. This fixes the error message currently seen in Ubuntu images:
```
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```

**NOTE:** This also includes a tweak to `apt installs` where we now use `--no-install-recommends`