### PR TITLE
Remove `conda activate base` from /etc/skel

### DIFF
--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -82,7 +82,6 @@ RUN wget --quiet ${MINICONDA_URL} -O /miniconda.sh \
     && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
     && echo "conda activate base" >> ~/.bashrc \
     && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/skel/.bashrc \
-    && echo "conda activate base" >> /etc/skel/.bashrc \
     && chmod -R ugo+w /opt/conda \
     && ln -s /opt/conda /conda
 


### PR DESCRIPTION
This PR removes `conda activate base` from `/etc/skel/.bashrc` to prevent the `base` conda environment from being activated on top of the `rapids` conda environment in `rapidsai/docker` images.