### PR TITLE
ENH Update conda to 4.8.3

### DIFF
--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -92,6 +92,7 @@ RUN wget --quiet ${MINICONDA_URL} -O /miniconda.sh \
     && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
     && echo "conda activate base" >> ~/.bashrc \
     && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/skel/.bashrc \
+    && echo "auto_update_conda: False" >> /opt/conda/.condarc \
     && chmod -R ugo+w /opt/conda \
     && ln -s /opt/conda /conda
 

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -9,9 +9,9 @@ ARG FULL_CUDA_VER
 ARG LINUX_VER
 
 # Define versions and download locations
-ARG CONDA_VER=4.7.12
+ARG CONDA_VER=4.8.3
 ARG TINI_VER=v0.18.0
-ARG MINICONDA_URL=http://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VER}-Linux-x86_64.sh
+ARG MINICONDA_URL=http://repo.anaconda.com/miniconda/Miniconda3-py38_${CONDA_VER}-Linux-x86_64.sh
 ARG TINI_URL=https://github.com/krallin/tini/releases/download/${TINI_VER}/tini
 
 # Set environment

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -21,6 +21,7 @@ SHELL ["/bin/bash", "-c"]
 # Add a condarc for channels and override settings
 RUN if [ "${RAPIDS_CHANNEL}" == "rapidsai" ] ; then \
       echo -e "\
+auto_update_conda: False \n\
 ssl_verify: False \n\
 channels: \n\
   - gpuci \n\
@@ -31,6 +32,7 @@ channels: \n\
       && cat /opt/conda/.condarc ; \
     else \
       echo -e "\
+auto_update_conda: False \n\
 ssl_verify: False \n\
 channels: \n\
   - gpuci \n\

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -59,8 +59,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
       "setuptools<50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc \
-    && cp /opt/conda/.condarc /opt/conda/envs/rapids/
+    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
 # Create symlink for old scripts expecting `gdf` conda env
 RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -29,6 +29,7 @@ SHELL ["/bin/bash", "-c"]
 # Add a condarc for channels and override settings
 RUN if [ "${RAPIDS_CHANNEL}" == "rapidsai" ] ; then \
       echo -e "\
+auto_update_conda: False \n\
 ssl_verify: False \n\
 channels: \n\
   - gpuci \n\
@@ -39,6 +40,7 @@ channels: \n\
       && cat /opt/conda/.condarc ; \
     else \
       echo -e "\
+auto_update_conda: False \n\
 ssl_verify: False \n\
 channels: \n\
   - gpuci \n\

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -91,8 +91,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
       "setuptools<50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc \
-    && cp /opt/conda/.condarc /opt/conda/envs/rapids/
+    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
 # Create symlink for old scripts expecting `gdf` conda env
 RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -27,6 +27,7 @@ SHELL ["/bin/bash", "-c"]
 # Add a condarc for channels and override settings
 RUN if [ "${RAPIDS_CHANNEL}" == "rapidsai" ] ; then \
       echo -e "\
+auto_update_conda: False \n\
 ssl_verify: False \n\
 channels: \n\
   - gpuci \n\
@@ -37,6 +38,7 @@ channels: \n\
       && cat /opt/conda/.condarc ; \
     else \
       echo -e "\
+auto_update_conda: False \n\
 ssl_verify: False \n\
 channels: \n\
   - gpuci \n\

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -108,8 +108,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
       "setuptools<50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc \
-    && cp /opt/conda/.condarc /opt/conda/envs/rapids/
+    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
 # Create symlink for old scripts expecting `gdf` conda env
 RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf


### PR DESCRIPTION
There are a number of changes and patches to retry on HTTP errors as well as performance improvements we can take advantage of from the [release notes](https://github.com/conda/conda/blob/master/CHANGELOG.md)

**UPDATE:** The latest [available](https://repo.anaconda.com/miniconda/) `miniconda` package is `4.8.3`; `miniforge` is `4.8.5`. Switching to `4.8.3` and will post `miniforge` images in a future PR