### PR TITLE
ENH Add Ubuntu 20.04 & CentOS 8 miniconda-cuda images

### DIFF
--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -30,11 +30,29 @@ IMAGE_TYPE:
 LINUX_VER:
   - ubuntu16.04
   - ubuntu18.04
+  - ubuntu20.04
   - centos7
+  - centos8
 
 exclude:
   - CUDA_VER: 9.0.176
     LINUX_VER: ubuntu18.04
+  - CUDA_VER: 9.0.176
+    LINUX_VER: ubuntu20.04
+  - CUDA_VER: 9.2.148
+    LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.0.130
+    LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.1.243
+    LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.2.89
+    LINUX_VER: ubuntu20.04
+  - CUDA_VER: 9.0.176
+    LINUX_VER: centos8
+  - CUDA_VER: 9.2.148
+    LINUX_VER: centos8
+  - CUDA_VER: 10.0.130
+    LINUX_VER: centos8
 # Uncomment below and `- gpuci/cuda` above to build using gpuCI CUDA images
 # NOTE: gpuci/cuda:11.0* is 11.0.194 and would need CUDA_VER to change on revert
 #  - CUDA_VER: 9.0.176

--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -15,6 +15,7 @@ DOCKER_FILE:
 #   so it can be used in all images within gpuCI; to make parsing easier we add
 #   it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
+  - 11.1.74
   - 11.0.221
   - 10.2.89
   - 10.1.243

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -28,7 +28,7 @@ ENV CUDA_VERSION=${FULL_CUDA_VER}
 SHELL ["/bin/bash", "-c"]
 
 # Update and add pkgs for Ubuntu, also generate locales for 'en_US.UTF-8'
-RUN if [ "${LINUX_VER}" != "centos7" ] ; then \
+RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
       apt-get update \
       && apt-get install -y --no-install-recommends \
         autoconf \
@@ -50,10 +50,16 @@ RUN if [ "${LINUX_VER}" != "centos7" ] ; then \
       echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'ubuntu16.04' or 'ubuntu18.04'\n\n"; \
     fi
 
-# Update and add pkgs for centOS
+# Disable CUDA repo using the appropriate manager
 RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
-      yum-config-manager --disable cuda \
-      && yum -y update \
+      yum-config-manager --disable cuda ; \
+    elif [ "${LINUX_VER}" == "centos8" ] ; then \
+      dnf config-manager --disable cuda ; \
+    fi
+
+# Update and add pkgs for CentOS
+RUN if [ "${LINUX_VER:0:6}" == "centos" ] ; then \
+      yum -y update \
       && yum remove -y bind-license \
       && yum -y install \
         autoconf \
@@ -69,7 +75,7 @@ RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
         which \
       && yum clean all ; \
     else \
-      echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'centos7'\n\n"; \
+      echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'centos7' or 'centos8'\n\n"; \
     fi
 
 # Install miniconda and configure

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -51,10 +51,14 @@ RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
     fi
 
 # Disable CUDA repo using the appropriate manager
+#   Also add langpack for locale in CentOS 8
 RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
       yum-config-manager --disable cuda ; \
     elif [ "${LINUX_VER}" == "centos8" ] ; then \
-      dnf config-manager --disable cuda ; \
+      dnf install -y \
+        'dnf-command(config-manager)' \
+        glibc-langpack-en \
+      && dnf config-manager --set-disabled cuda ; \
     fi
 
 # Update and add pkgs for CentOS


### PR DESCRIPTION
As as request for other repos and to prepare for future releases we are adding `miniconda-cuda` images for Ubuntu 20.04 & Centos 8 for their available CUDA versions