### PR TITLE
FIX Link root `.condarc` in `rapids` env

### DIFF
--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -57,7 +57,8 @@ RUN source activate base \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
       "setuptools<50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc \
+    && ln -s /opt/conda/.condarc /opt/conda/evns/rapids/.condarc
 
 # Create symlink for old scripts expecting `gdf` conda env
 RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -90,7 +90,8 @@ RUN source activate base \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
       "setuptools<50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc \
+    && ln -s /opt/conda/.condarc /opt/conda/evns/rapids/.condarc
 
 # Create symlink for old scripts expecting `gdf` conda env
 RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -107,7 +107,8 @@ RUN source activate base \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
       "setuptools<50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc \
+    && ln -s /opt/conda/.condarc /opt/conda/evns/rapids/.condarc
 
 # Create symlink for old scripts expecting `gdf` conda env
 RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf


### PR DESCRIPTION
This fixes an issue with `gpuci-tools` where `gpuci_conda_retry` and `gpuci_retry` do not see the same channel information and cause install errors. There appears to be an environment change when calling `conda` from these wrapper function resulting in missing channel definitions set in the root `/opt/conda/.condarc`. Creating a symlink in `/opt/conda/envs/rapids/.condarc` to the root `/opt/conda/.condarc` solves this issue.

Discovered while trying to complete rapidsai/cudf#6329