### PR TITLE
FIX Patch PR #137 by copying `.condarc` instead of symlink

### DIFF
--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -43,9 +43,9 @@ channels: \n\
     fi
 
 # Create rapids conda env and make default
-RUN source activate base \
-    && conda install -y gpuci-tools \
-    && gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN conda install -y gpuci-tools \
+    || conda install -y gpuci-tools
+RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c defaults \

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -58,7 +58,7 @@ RUN source activate base \
       python=${PYTHON_VER} \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc \
-    && cp /opt/conda/.condarc /opt/conda/evns/rapids/
+    && cp /opt/conda/.condarc /opt/conda/envs/rapids/
 
 # Create symlink for old scripts expecting `gdf` conda env
 RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -58,7 +58,7 @@ RUN source activate base \
       python=${PYTHON_VER} \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc \
-    && ln -s /opt/conda/.condarc /opt/conda/evns/rapids/.condarc
+    && cp /opt/conda/.condarc /opt/conda/evns/rapids/
 
 # Create symlink for old scripts expecting `gdf` conda env
 RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -27,8 +27,8 @@ channels: \n\
   - rapidsai \n\
   - conda-forge \n\
   - nvidia \n\
-  - defaults \n" > /conda/.condarc \
-      && cat /conda/.condarc ; \
+  - defaults \n" > /opt/conda/.condarc \
+      && cat /opt/conda/.condarc ; \
     else \
       echo -e "\
 ssl_verify: False \n\
@@ -38,8 +38,8 @@ channels: \n\
   - rapidsai-nightly \n\
   - conda-forge \n\
   - nvidia \n\
-  - defaults \n" > /conda/.condarc \
-      && cat /conda/.condarc ; \
+  - defaults \n" > /opt/conda/.condarc \
+      && cat /opt/conda/.condarc ; \
     fi
 
 # Create rapids conda env and make default

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -91,7 +91,7 @@ RUN source activate base \
       python=${PYTHON_VER} \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc \
-    && ln -s /opt/conda/.condarc /opt/conda/evns/rapids/.condarc
+    && cp /opt/conda/.condarc /opt/conda/evns/rapids/
 
 # Create symlink for old scripts expecting `gdf` conda env
 RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -91,7 +91,7 @@ RUN source activate base \
       python=${PYTHON_VER} \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc \
-    && cp /opt/conda/.condarc /opt/conda/evns/rapids/
+    && cp /opt/conda/.condarc /opt/conda/envs/rapids/
 
 # Create symlink for old scripts expecting `gdf` conda env
 RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -70,15 +70,14 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     && rm -rf ./aws ./awscliv2.zip
 
 # Add core tools to base env
-RUN source activate base \
-    && conda install -y gpuci-tools \
-    && gpuci_conda_retry install -y \
+RUN conda install -y gpuci-tools \
+    || conda install -y gpuci-tools
+RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov
 
 # Create `rapids` conda env and make default
-RUN source activate base \
-    && gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c defaults \
@@ -100,8 +99,7 @@ RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN source activate base \
-    && gpuci_conda_retry install -y -n rapids --freeze-installed \
+RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -35,8 +35,8 @@ channels: \n\
   - rapidsai \n\
   - conda-forge \n\
   - nvidia \n\
-  - defaults \n" > /conda/.condarc \
-      && cat /conda/.condarc ; \
+  - defaults \n" > /opt/conda/.condarc \
+      && cat /opt/conda/.condarc ; \
     else \
       echo -e "\
 ssl_verify: False \n\
@@ -46,8 +46,8 @@ channels: \n\
   - rapidsai-nightly \n\
   - conda-forge \n\
   - nvidia \n\
-  - defaults \n" > /conda/.condarc \
-      && cat /conda/.condarc ; \
+  - defaults \n" > /opt/conda/.condarc \
+      && cat /opt/conda/.condarc ; \
     fi
 
 # Update and add pkgs for gpuci builds

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -108,7 +108,7 @@ RUN source activate base \
       python=${PYTHON_VER} \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc \
-    && ln -s /opt/conda/.condarc /opt/conda/evns/rapids/.condarc
+    && cp /opt/conda/.condarc /opt/conda/evns/rapids/
 
 # Create symlink for old scripts expecting `gdf` conda env
 RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -108,7 +108,7 @@ RUN source activate base \
       python=${PYTHON_VER} \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc \
-    && cp /opt/conda/.condarc /opt/conda/evns/rapids/
+    && cp /opt/conda/.condarc /opt/conda/envs/rapids/
 
 # Create symlink for old scripts expecting `gdf` conda env
 RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -87,15 +87,14 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     && rm -rf ./aws ./awscliv2.zip
 
 # Add core tools to base env
-RUN source activate base \
-    && conda install -y gpuci-tools \
-    && gpuci_conda_retry install -y \
+RUN conda install -y gpuci-tools \
+    || conda install -y gpuci-tools
+RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov
 
 # Create `rapids` conda env and make default
-RUN source activate base \
-    && gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c defaults \
@@ -117,8 +116,7 @@ RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN source activate base \
-    && gpuci_conda_retry install -y -n rapids --freeze-installed \
+RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -33,8 +33,8 @@ channels: \n\
   - rapidsai \n\
   - conda-forge \n\
   - nvidia \n\
-  - defaults \n" > /conda/.condarc \
-      && cat /conda/.condarc ; \
+  - defaults \n" > /opt/conda/.condarc \
+      && cat /opt/conda/.condarc ; \
     else \
       echo -e "\
 ssl_verify: False \n\
@@ -44,8 +44,8 @@ channels: \n\
   - rapidsai-nightly \n\
   - conda-forge \n\
   - nvidia \n\
-  - defaults \n" > /conda/.condarc \
-      && cat /conda/.condarc ; \
+  - defaults \n" > /opt/conda/.condarc \
+      && cat /opt/conda/.condarc ; \
     fi
 
 # Install gcc7 - 7.5.0 to bring build stack in line with conda-forge


### PR DESCRIPTION
Despite testing in #137 that passed, when trying to build containers after the PR merge no `rapidsai` containers would build due to symlink errors. This approach copies the file instead which will result in a more consistent state if the `.condarc` file is modified for the `rapids` env, it will leave the `base` env intact.