### PR TITLE
FIX .condarc channel order

### DIFF
--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -34,8 +34,8 @@ channels: \n\
 ssl_verify: False \n\
 channels: \n\
   - gpuci \n\
-  - rapidsai \n\
   - rapidsai-nightly \n\
+  - rapidsai \n\
   - conda-forge \n\
   - nvidia \n\
   - defaults \n" > /opt/conda/.condarc \

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -42,8 +42,8 @@ channels: \n\
 ssl_verify: False \n\
 channels: \n\
   - gpuci \n\
-  - rapidsai \n\
   - rapidsai-nightly \n\
+  - rapidsai \n\
   - conda-forge \n\
   - nvidia \n\
   - defaults \n" > /opt/conda/.condarc \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -40,8 +40,8 @@ channels: \n\
 ssl_verify: False \n\
 channels: \n\
   - gpuci \n\
-  - rapidsai \n\
   - rapidsai-nightly \n\
+  - rapidsai \n\
   - conda-forge \n\
   - nvidia \n\
   - defaults \n" > /opt/conda/.condarc \


### PR DESCRIPTION
The current channel order creates an issue where the pkgs installed into the `rapids` env are not the most current ones as they are installing some from `rapidsai` which are older and should be installed from `rapidsai-nightly`. Rearranging the channels should fix this issue.

- [x] Build test images with this PR
- [x] Check that `rapidsai` images have the correct pkgs in `rapids` conda env

Test results from `conda list` on the current image and the new image from this PR
```
(base) mwendt-mlt:cl mwendt$ diff current pr139
65c65
< cmake_setuptools          0.1.3                      py_0    rapidsai
---
> cmake_setuptools          0.1.3                      py_0    rapidsai-nightly
79c79
< cupy                      7.8.0            py38hb7c6141_0    rapidsai
---
> cupy                      8.0.0            py38hb7c6141_0    rapidsai-nightly
202c202
< libcypher-parser          0.6.2                         1    rapidsai
---
> libcypher-parser          0.6.2                         1    rapidsai-nightly
207c207
< libfaiss                  1.6.3           h328c4c8_1_cuda    rapidsai
---
> libfaiss                  1.6.3           h328c4c8_1_cuda    rapidsai-nightly
430,431c430,431
< ucx                       1.8.1+g6b29558       cuda11.0_0    rapidsai
< ucx-proc                  1.0.0                       gpu    rapidsai
---
> ucx                       1.8.1+g6b29558       cuda11.0_0    rapidsai-nightly
> ucx-proc                  1.0.0                       gpu    rapidsai-nightly
```