### PR TITLE
FIX Order nvidia channel before conda-forge

### DIFF
--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -25,8 +25,8 @@ ssl_verify: False \n\
 channels: \n\
   - gpuci \n\
   - rapidsai \n\
-  - conda-forge \n\
   - nvidia \n\
+  - conda-forge \n\
   - defaults \n" > /opt/conda/.condarc \
       && cat /opt/conda/.condarc ; \
     else \
@@ -36,8 +36,8 @@ channels: \n\
   - gpuci \n\
   - rapidsai-nightly \n\
   - rapidsai \n\
-  - conda-forge \n\
   - nvidia \n\
+  - conda-forge \n\
   - defaults \n" > /opt/conda/.condarc \
       && cat /opt/conda/.condarc ; \
     fi

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -33,8 +33,8 @@ ssl_verify: False \n\
 channels: \n\
   - gpuci \n\
   - rapidsai \n\
-  - conda-forge \n\
   - nvidia \n\
+  - conda-forge \n\
   - defaults \n" > /opt/conda/.condarc \
       && cat /opt/conda/.condarc ; \
     else \
@@ -44,8 +44,8 @@ channels: \n\
   - gpuci \n\
   - rapidsai-nightly \n\
   - rapidsai \n\
-  - conda-forge \n\
   - nvidia \n\
+  - conda-forge \n\
   - defaults \n" > /opt/conda/.condarc \
       && cat /opt/conda/.condarc ; \
     fi

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -31,8 +31,8 @@ ssl_verify: False \n\
 channels: \n\
   - gpuci \n\
   - rapidsai \n\
-  - conda-forge \n\
   - nvidia \n\
+  - conda-forge \n\
   - defaults \n" > /opt/conda/.condarc \
       && cat /opt/conda/.condarc ; \
     else \
@@ -42,8 +42,8 @@ channels: \n\
   - gpuci \n\
   - rapidsai-nightly \n\
   - rapidsai \n\
-  - conda-forge \n\
   - nvidia \n\
+  - conda-forge \n\
   - defaults \n" > /opt/conda/.condarc \
       && cat /opt/conda/.condarc ; \
     fi


### PR DESCRIPTION
The `nvidia` channel should be before `conda-forge` to pick up the correct packages and to ensure there are no conflicts. Right now in CUDA 11 gpuCI builds there are conflicts with mismatched packages that lead to an unsolvable conda install. This should address the issue.