### PR TITLE
[REVIEW] FIX Add chrpath to CentOS images

### DIFF
--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -54,6 +54,7 @@ channels: \n\
 
 # Update and add pkgs for gpuci builds
 RUN yum install -y \
+      chrpath \
       clang \
       numactl-devel \
       numactl-libs \


### PR DESCRIPTION
`chrpath` was recently added to some of our scripts to support Project Flash. CentOS does not have this tool by default.