### PR TITLE
Add python 3.9 gpuci build target image axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ destination image.
 
 ### Image Flow Diagram
 
-![gpuCI images and relations](gpuci-images.png)
+![gpuCI images and relations](gpuci-images.png) 
 
 ## Public Images
 

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -36,6 +36,7 @@ LINUX_VER:
 PYTHON_VER:
   - 3.7
   - 3.8
+  - 3.9
 
 exclude:
   - IMAGE_TYPE: base


### PR DESCRIPTION
# Summary
This PR adds python3.9 build targets to the gpuci build environment axis