### PR TITLE
add ubuntu 20.04, centos8 ci axes

### DIFF
--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -46,8 +46,12 @@ exclude:
     LINUX_VER: ubuntu20.04
   - CUDA_VER: 10.1.243
     LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.1.243
+    LINUX_VER: centos8
   - CUDA_VER: 10.2.89
     LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.2.89
+    LINUX_VER: centos8
   - CUDA_VER: 9.0.176
     LINUX_VER: centos8
   - CUDA_VER: 9.2.148

--- a/ci/axis/miniforge-cuda.yml
+++ b/ci/axis/miniforge-cuda.yml
@@ -48,8 +48,12 @@ exclude:
     LINUX_VER: ubuntu20.04
   - CUDA_VER: 10.1.243
     LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.1.243
+    LINUX_VER: centos8
   - CUDA_VER: 10.2.89
     LINUX_VER: ubuntu20.04
+  - CUDA_VER: 10.2.89
+    LINUX_VER: centos8
   - CUDA_VER: 9.0.176
     LINUX_VER: centos8
   - CUDA_VER: 9.2.148

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -32,7 +32,9 @@ IMAGE_TYPE:
 LINUX_VER:
   - ubuntu16.04
   - ubuntu18.04
+  - ubuntu20.04
   - centos7
+  - centos8
 
 PYTHON_VER:
   - 3.7
@@ -56,3 +58,5 @@ exclude:
     LINUX_VER: ubuntu16.04
   - DOCKER_FILE: devel-centos7.Dockerfile
     LINUX_VER: ubuntu18.04
+  - DOCKER_FILE: devel-centos7.Dockerfile
+    LINUX_VER: ubuntu20.04

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -54,9 +54,20 @@ exclude:
   - IMAGE_TYPE: devel
     DOCKER_FILE: devel.Dockerfile
     LINUX_VER: centos7
+  - IMAGE_TYPE: devel
+    DOCKER_FILE: devel.Dockerfile
+    LINUX_VER: centos8
   - DOCKER_FILE: devel-centos7.Dockerfile
     LINUX_VER: ubuntu16.04
   - DOCKER_FILE: devel-centos7.Dockerfile
     LINUX_VER: ubuntu18.04
   - DOCKER_FILE: devel-centos7.Dockerfile
     LINUX_VER: ubuntu20.04
+  - LINUX_VER: ubuntu20.04
+    CUDA_VER: 10.1
+  - LINUX_VER: centos8
+    CUDA_VER: 10.1
+  - LINUX_VER: ubuntu20.04
+    CUDA_VER: 10.2
+  - LINUX_VER: centos8
+    CUDA_VER: 10.2


### PR DESCRIPTION
# Summary
This PR adds support for Ubuntu 20.04 and Centos 8 to our gpuci build environment.