### PR TITLE
[REVIEW] ENH Add pytorch to condarc

### DIFF
--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -27,6 +27,7 @@ channels: \n\
   - gpuci \n\
   - rapidsai \n\
   - nvidia \n\
+  - pytorch \n\
   - conda-forge \n\
   - defaults \n" > /opt/conda/.condarc \
       && cat /opt/conda/.condarc ; \
@@ -39,6 +40,7 @@ channels: \n\
   - rapidsai-nightly \n\
   - rapidsai \n\
   - nvidia \n\
+  - pytorch \n\
   - conda-forge \n\
   - defaults \n" > /opt/conda/.condarc \
       && cat /opt/conda/.condarc ; \

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -35,6 +35,7 @@ channels: \n\
   - gpuci \n\
   - rapidsai \n\
   - nvidia \n\
+  - pytorch \n\
   - conda-forge \n\
   - defaults \n" > /opt/conda/.condarc \
       && cat /opt/conda/.condarc ; \
@@ -47,6 +48,7 @@ channels: \n\
   - rapidsai-nightly \n\
   - rapidsai \n\
   - nvidia \n\
+  - pytorch \n\
   - conda-forge \n\
   - defaults \n" > /opt/conda/.condarc \
       && cat /opt/conda/.condarc ; \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -33,6 +33,7 @@ channels: \n\
   - gpuci \n\
   - rapidsai \n\
   - nvidia \n\
+  - pytorch \n\
   - conda-forge \n\
   - defaults \n" > /opt/conda/.condarc \
       && cat /opt/conda/.condarc ; \
@@ -45,6 +46,7 @@ channels: \n\
   - rapidsai-nightly \n\
   - rapidsai \n\
   - nvidia \n\
+  - pytorch \n\
   - conda-forge \n\
   - defaults \n" > /opt/conda/.condarc \
       && cat /opt/conda/.condarc ; \


### PR DESCRIPTION
Add pytorch to condarc for upcoming Blazing images that require pytorch for notebooks.