### PR TITLE
FIX Update axis for v0.18

### DIFF
--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -12,6 +12,7 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - 0.17
+  - 0.18
 
 CUDA_VER:
   - 11.0

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -14,6 +14,7 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - 0.17
+  - 0.18
 
 RAPIDS_CHANNEL:
   - rapidsai-nightly


### PR DESCRIPTION
Blocks rapidsai/docker#222
Blocked by rapidsai/integration#180

These axis updates are needed to create images to be used for rapidsai/docker#222