### PR TITLE
ENH Remove 0.17 from axis

### DIFF
--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - Dockerfile
 
 RAPIDS_VER:
-  - 0.17
   - 0.18
 
 CUDA_VER:

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -13,7 +13,6 @@ DOCKER_FILE:
   - devel-centos7.Dockerfile
 
 RAPIDS_VER:
-  - 0.17
   - 0.18
 
 RAPIDS_CHANNEL:


### PR DESCRIPTION
0.17 has been released and no longer requires nightly builds