### PR TITLE
Ensure cpython python packages are always selected

### DIFF
--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -60,6 +60,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
+      python_abi=*=*cp* \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -60,7 +60,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
-      python_abi=*=*cp* \
+      'python_abi=*=*cp*' \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -93,7 +93,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
-      python_abi=*=*cp* \
+      'python_abi=*=*cp*' \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -93,6 +93,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
+      python_abi=*=*cp* \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -109,6 +109,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
+      python_abi=*=*cp* \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -109,7 +109,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
-      python_abi=*=*cp* \
+      'python_abi=*=*cp*' \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 


### PR DESCRIPTION
A change to conda packages caused our 3.7 images to use `pypy` Python packages which we do not support. This change ensures that `cpython` packages are always used.