### PR TITLE
ENH Update build stack to gcc/gxx 9

### DIFF
--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -39,6 +39,9 @@ PYTHON_VER:
   - 3.7
   - 3.8
 
+BUILD_STACK_VER:
+  - 9.3.0
+
 exclude:
   - IMAGE_TYPE: base
     DOCKER_FILE: devel.Dockerfile

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -4,6 +4,9 @@ set -e
 # Overwrite HOME to WORKSPACE
 export HOME=$WORKSPACE
 
+# TODO Remove after Jenkins jobs are updated
+export BUILD_STACK_VER=9.3.0
+
 # Install gpuCI tools
 curl -s https://raw.githubusercontent.com/rapidsai/gpuci-tools/main/install.sh | bash
 source ~/.bashrc

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -86,6 +86,13 @@ else
   echo "ARCH_TYPE is set to '$ARCH_TYPE', adding to build args..."
   BUILD_ARGS="${BUILD_ARGS} --build-arg ARCH_TYPE=${ARCH_TYPE}"
 fi
+# Check if BUILD_STACK_VER is set
+if [ -z "$BUILD_STACK_VER" ] ; then
+  echo "BUILD_STACK_VER is not set, skipping..."
+else
+  echo "BUILD_STACK_VER is set to '$BUILD_STACK_VER', adding to build args..."
+  BUILD_ARGS="${BUILD_ARGS} --build-arg BUILD_STACK_VER=${BUILD_STACK_VER}"
+fi
 
 # Ouput build config
 gpuci_logger "Build config info..."


### PR DESCRIPTION
Updates the default build stack for `rapids` conda environment to `9.3.0` to match the new version in conda-forge

- [x] Update gpuCI jobs to use the new axis config parameter `BUILD_STACK_VER`