### PR TITLE
[REVIEW] ENH Add rapids-scout-local to gpuCI images

### DIFF
--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -79,7 +79,8 @@ RUN conda install -y gpuci-tools \
     || conda install -y gpuci-tools
 RUN gpuci_conda_retry install -y \
       anaconda-client \
-      codecov
+      codecov \
+      rapids-scout-local
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -95,7 +95,8 @@ RUN conda install -y gpuci-tools \
     || conda install -y gpuci-tools
 RUN gpuci_conda_retry install -y \
       anaconda-client \
-      codecov
+      codecov \
+      rapids-scout-local
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \


### PR DESCRIPTION
Adds the rapids-scout-local package to the gpuci environment. This package contains a compatible gpuci-ccache and cmake, allowing us to utilize cached builds.