### PR TITLE
FIX Update gcc7 builds to use gcc9 libstdc++.so

### DIFF
--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -54,7 +54,7 @@ RUN rm -rfv ${GCC7_DIR}/lib64/libstdc++.* \
     && ls -la ${GCC7_DIR}/lib64/libstdc++.*
 
 # Pull gcc9's headers into gcc7's
-RUN rm -rfv ${GCC7_DIR}/include/c++/${GCC7_VER}/* \
-    && ls -la ${GCC9_DIR}/include/c++/${GCC9_VER}/* \
-    && cp -av ${GCC9_DIR}/include/c++/${GCC9_VER}/* ${GCC7_DIR}/include/c++/${GCC7_VER} \
-    && ls -la ${GCC7_DIR}/include/c++/${GCC7_VER}/*
+RUN rm -rfv ${GCC7_DIR}/include/c++/7.5.0/* \
+    && ls -la ${GCC9_DIR}/include/c++/9.3.0/* \
+    && cp -av ${GCC9_DIR}/include/c++/9.3.0/* ${GCC7_DIR}/include/c++/7.5.0 \
+    && ls -la ${GCC7_DIR}/include/c++/7.5.0/*

--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -6,9 +6,9 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-${CUDA_TYPE}-${LINUX_VER}
 
 # Define arguments
 ARG GCC7_DIR=/usr/local/gcc7
-ARG GCC7_VER=gcc-7.5.0
+ARG GCC7_VER=7.5.0
 ARG GCC9_DIR=/usr/local/gcc9
-ARG GCC9_VER=gcc-9.3.0
+ARG GCC9_VER=9.3.0
 ARG NUM_BUILD_CPUS=16
 
 # Add /usr/local/cuda/* temporarily to LD_LIBRARY_PATH to support various build steps
@@ -31,21 +31,21 @@ RUN yum upgrade -y \
 # NOTE: this step requires packages gmp-devel, mpfr-devel,
 # libmpc-devel, and file (see above)
 RUN mkdir -p ${GCC7_DIR} \
-    && cd ${GCC7_DIR} && wget -q http://ftp.gnu.org/gnu/gcc/${GCC7_VER}/${GCC7_VER}.tar.gz \
-    && cd ${GCC7_DIR} && tar zxf ${GCC7_VER}.tar.gz \
-    && cd ${GCC7_DIR}/${GCC7_VER} \
+    && cd ${GCC7_DIR} && wget -q http://ftp.gnu.org/gnu/gcc/gcc-${GCC7_VER}/gcc-${GCC7_VER}.tar.gz \
+    && cd ${GCC7_DIR} && tar zxf gcc-${GCC7_VER}.tar.gz \
+    && cd ${GCC7_DIR}/gcc-${GCC7_VER} \
     && ./configure --prefix=${GCC7_DIR} --disable-multilib \
     && make -j${NUM_BUILD_CPUS} && make install \
-    && rm -r ${GCC7_DIR}/${GCC7_VER} ${GCC7_DIR}/${GCC7_VER}.tar.gz
+    && rm -r ${GCC7_DIR}/gcc-${GCC7_VER} ${GCC7_DIR}/gcc-${GCC7_VER}.tar.gz
 
 # Build gcc 9
 RUN mkdir -p ${GCC9_DIR} \
-    && cd ${GCC9_DIR} && wget -q http://ftp.gnu.org/gnu/gcc/${GCC9_VER}/${GCC9_VER}.tar.gz \
-    && cd ${GCC9_DIR} && tar zxf ${GCC9_VER}.tar.gz \
-    && cd ${GCC9_DIR}/${GCC9_VER} \
+    && cd ${GCC9_DIR} && wget -q http://ftp.gnu.org/gnu/gcc/gcc-${GCC9_VER}/gcc-${GCC9_VER}.tar.gz \
+    && cd ${GCC9_DIR} && tar zxf gcc-${GCC9_VER}.tar.gz \
+    && cd ${GCC9_DIR}/gcc-${GCC9_VER} \
     && ./configure --prefix=${GCC9_DIR} --disable-multilib \
     && make -j${NUM_BUILD_CPUS} && make install \
-    && rm -r ${GCC9_DIR}/${GCC9_VER} ${GCC9_DIR}/${GCC9_VER}.tar.gz
+    && rm -r ${GCC9_DIR}/gcc-${GCC9_VER} ${GCC9_DIR}/gcc-${GCC9_VER}.tar.gz
 
 # Pull gcc9's libstdc++ into gcc7's lib64
 RUN rm -rfv ${GCC7_DIR}/lib64/libstdc++.* \
@@ -54,7 +54,7 @@ RUN rm -rfv ${GCC7_DIR}/lib64/libstdc++.* \
     && ls -la ${GCC7_DIR}/lib64/libstdc++.*
 
 # Pull gcc9's headers into gcc7's
-RUN rm -rfv ${GCC7_DIR}/include/c++/7.5.0/* \
-    && ls -la ${GCC9_DIR}/include/c++/9.3.0/* \
-    && cp -av ${GCC9_DIR}/include/c++/9.3.0/* ${GCC7_DIR}/include/c++/7.5.0 \
-    && ls -la ${GCC7_DIR}/include/c++/7.5.0/*
+RUN rm -rfv ${GCC7_DIR}/include/c++/${GCC7_VER}/* \
+    && ls -la ${GCC9_DIR}/include/c++/${GCC9_VER}/* \
+    && cp -av ${GCC9_DIR}/include/c++/${GCC9_VER}/* ${GCC7_DIR}/include/c++/${GCC7_VER} \
+    && ls -la ${GCC7_DIR}/include/c++/${GCC7_VER}/*

--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -7,6 +7,8 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-${CUDA_TYPE}-${LINUX_VER}
 # Define arguments
 ARG GCC7_DIR=/usr/local/gcc7
 ARG GCC7_VER=gcc-7.5.0
+ARG GCC9_DIR=/usr/local/gcc9
+ARG GCC9_VER=gcc-9.3.0
 ARG NUM_BUILD_CPUS=16
 
 # Add /usr/local/cuda/* temporarily to LD_LIBRARY_PATH to support various build steps
@@ -35,3 +37,17 @@ RUN mkdir -p ${GCC7_DIR} \
     && ./configure --prefix=${GCC7_DIR} --disable-multilib \
     && make -j${NUM_BUILD_CPUS} && make install \
     && rm -r ${GCC7_DIR}/${GCC7_VER} ${GCC7_DIR}/${GCC7_VER}.tar.gz
+
+# Build gcc 9
+RUN mkdir -p ${GCC9_DIR} \
+    && cd ${GCC9_DIR} && wget -q http://ftp.gnu.org/gnu/gcc/${GCC9_VER}/${GCC9_VER}.tar.gz \
+    && cd ${GCC9_DIR} && tar zxf ${GCC7_VER}.tar.gz \
+    && cd ${GCC9_DIR}/${GCC7_VER} \
+    && ./configure --prefix=${GCC9_DIR} --disable-multilib \
+    && make -j${NUM_BUILD_CPUS} \
+    && rm -r ${GCC9_DIR}/${GCC9_VER} ${GCC9_DIR}/${GCC9_VER}.tar.gz
+
+# Pull gcc9's libstdc++ into gcc7's lib64
+RUN rm -rfv ${GCC7_DIR}/lib64/libstdc++.so* \
+    && cp ${GCC9_DIR}/lib64/libstdc++.so* ${GCC7_DIR}/lib64 \
+    && ls -la ${GCC7_DIR}/lib64/libstdc++.so*

--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -48,6 +48,6 @@ RUN mkdir -p ${GCC9_DIR} \
     && rm -r ${GCC9_DIR}/${GCC9_VER} ${GCC9_DIR}/${GCC9_VER}.tar.gz
 
 # Pull gcc9's libstdc++ into gcc7's lib64
-RUN rm -rfv ${GCC7_DIR}/lib64/libstdc++.so* \
-    && cp ${GCC9_DIR}/lib64/libstdc++.so* ${GCC7_DIR}/lib64 \
-    && ls -la ${GCC7_DIR}/lib64/libstdc++.so*
+RUN rm -rfv ${GCC7_DIR}/lib64/libstdc++* \
+    && cp ${GCC9_DIR}/lib64/libstdc++* ${GCC7_DIR}/lib64 \
+    && ls -la ${GCC7_DIR}/lib64/libstdc++*

--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -52,3 +52,9 @@ RUN rm -rfv ${GCC7_DIR}/lib64/libstdc++.* \
     && ls -la ${GCC9_DIR}/lib64/libstdc++.* \
     && cp -av ${GCC9_DIR}/lib64/libstdc++.* ${GCC7_DIR}/lib64 \
     && ls -la ${GCC7_DIR}/lib64/libstdc++.*
+
+# Pull gcc9's headers into gcc7's
+RUN rm -rfv ${GCC7_DIR}/include/c++/${GCC7_VER}/* \
+    && ls -la ${GCC9_DIR}/include/c++/${GCC9_VER}/* \
+    && cp -av ${GCC9_DIR}/include/c++/${GCC9_VER}/* ${GCC7_DIR}/include/c++/${GCC7_VER} \
+    && ls -la ${GCC7_DIR}/include/c++/${GCC7_VER}/*

--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -44,11 +44,11 @@ RUN mkdir -p ${GCC9_DIR} \
     && cd ${GCC9_DIR} && tar zxf ${GCC9_VER}.tar.gz \
     && cd ${GCC9_DIR}/${GCC9_VER} \
     && ./configure --prefix=${GCC9_DIR} --disable-multilib \
-    && make -j${NUM_BUILD_CPUS} \
+    && make -j${NUM_BUILD_CPUS} && make install \
     && rm -r ${GCC9_DIR}/${GCC9_VER} ${GCC9_DIR}/${GCC9_VER}.tar.gz
 
 # Pull gcc9's libstdc++ into gcc7's lib64
-RUN rm -rfv ${GCC7_DIR}/lib64/libstdc++.* \
-    && ls -la ${GCC9_DIR}/lib64/libstdc++.* \
-    && cp -av ${GCC9_DIR}/lib64/libstdc++.* ${GCC7_DIR}/lib64 \
-    && ls -la ${GCC7_DIR}/lib64/libstdc++.*
+RUN rm -rfv "${GCC7_DIR}/lib64/libstdc++.*" \
+    && ls -la "${GCC9_DIR}/lib64/libstdc++.*" \
+    && cp -av "${GCC9_DIR}/lib64/libstdc++.*" ${GCC7_DIR}/lib64 \
+    && ls -la "${GCC7_DIR}/lib64/libstdc++.*"

--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -41,8 +41,8 @@ RUN mkdir -p ${GCC7_DIR} \
 # Build gcc 9
 RUN mkdir -p ${GCC9_DIR} \
     && cd ${GCC9_DIR} && wget -q http://ftp.gnu.org/gnu/gcc/${GCC9_VER}/${GCC9_VER}.tar.gz \
-    && cd ${GCC9_DIR} && tar zxf ${GCC7_VER}.tar.gz \
-    && cd ${GCC9_DIR}/${GCC7_VER} \
+    && cd ${GCC9_DIR} && tar zxf ${GCC9_VER}.tar.gz \
+    && cd ${GCC9_DIR}/${GCC9_VER} \
     && ./configure --prefix=${GCC9_DIR} --disable-multilib \
     && make -j${NUM_BUILD_CPUS} \
     && rm -r ${GCC9_DIR}/${GCC9_VER} ${GCC9_DIR}/${GCC9_VER}.tar.gz

--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -48,6 +48,7 @@ RUN mkdir -p ${GCC9_DIR} \
     && rm -r ${GCC9_DIR}/${GCC9_VER} ${GCC9_DIR}/${GCC9_VER}.tar.gz
 
 # Pull gcc9's libstdc++ into gcc7's lib64
-RUN rm -rfv ${GCC7_DIR}/lib64/libstdc++* \
-    && cp ${GCC9_DIR}/lib64/libstdc++* ${GCC7_DIR}/lib64 \
-    && ls -la ${GCC7_DIR}/lib64/libstdc++*
+RUN rm -rfv ${GCC7_DIR}/lib64/libstdc++.* \
+    && ls -la ${GCC9_DIR}/lib64/libstdc++.* \
+    && cp -av ${GCC9_DIR}/lib64/libstdc++.* ${GCC7_DIR}/lib64 \
+    && ls -la ${GCC7_DIR}/lib64/libstdc++.*

--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -49,6 +49,6 @@ RUN mkdir -p ${GCC9_DIR} \
 
 # Pull gcc9's libstdc++ into gcc7's lib64
 RUN rm -rfv "${GCC7_DIR}/lib64/libstdc++.*" \
-    && ls -la "${GCC9_DIR}/lib64/libstdc++.*" \
+    && ls -la "${GCC9_DIR}/lib64" \
     && cp -av "${GCC9_DIR}/lib64/libstdc++.*" ${GCC7_DIR}/lib64 \
-    && ls -la "${GCC7_DIR}/lib64/libstdc++.*"
+    && ls -la "${GCC7_DIR}/lib64"

--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -48,7 +48,7 @@ RUN mkdir -p ${GCC9_DIR} \
     && rm -r ${GCC9_DIR}/${GCC9_VER} ${GCC9_DIR}/${GCC9_VER}.tar.gz
 
 # Pull gcc9's libstdc++ into gcc7's lib64
-RUN rm -rfv "${GCC7_DIR}/lib64/libstdc++.so*" \
-    && ls -la "${GCC9_DIR}/lib64" \
-    && cp -av "${GCC9_DIR}/lib64/libstdc++.so*" ${GCC7_DIR}/lib64 \
-    && ls -la "${GCC7_DIR}/lib64"
+RUN rm -rfv ${GCC7_DIR}/lib64/libstdc++.* \
+    && ls -la ${GCC9_DIR}/lib64/libstdc++.* \
+    && cp -av ${GCC9_DIR}/lib64/libstdc++.* ${GCC7_DIR}/lib64 \
+    && ls -la ${GCC7_DIR}/lib64/libstdc++.*

--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -52,9 +52,3 @@ RUN rm -rfv ${GCC7_DIR}/lib64/libstdc++.* \
     && ls -la ${GCC9_DIR}/lib64/libstdc++.* \
     && cp -av ${GCC9_DIR}/lib64/libstdc++.* ${GCC7_DIR}/lib64 \
     && ls -la ${GCC7_DIR}/lib64/libstdc++.*
-
-# Pull gcc9's headers into gcc7's
-RUN rm -rfv ${GCC7_DIR}/include/c++/${GCC7_VER}/* \
-    && ls -la ${GCC9_DIR}/include/c++/${GCC9_VER}/* \
-    && cp -av ${GCC9_DIR}/include/c++/${GCC9_VER}/* ${GCC7_DIR}/include/c++/${GCC7_VER} \
-    && ls -la ${GCC7_DIR}/include/c++/${GCC7_VER}/*

--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -48,7 +48,7 @@ RUN mkdir -p ${GCC9_DIR} \
     && rm -r ${GCC9_DIR}/${GCC9_VER} ${GCC9_DIR}/${GCC9_VER}.tar.gz
 
 # Pull gcc9's libstdc++ into gcc7's lib64
-RUN rm -rfv "${GCC7_DIR}/lib64/libstdc++.*" \
+RUN rm -rfv "${GCC7_DIR}/lib64/libstdc++.so*" \
     && ls -la "${GCC9_DIR}/lib64" \
-    && cp -av "${GCC9_DIR}/lib64/libstdc++.*" ${GCC7_DIR}/lib64 \
+    && cp -av "${GCC9_DIR}/lib64/libstdc++.so*" ${GCC7_DIR}/lib64 \
     && ls -la "${GCC7_DIR}/lib64"

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -51,8 +51,10 @@ RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
       echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'ubuntu16.04' or 'ubuntu18.04'\n\n"; \
     fi
 
-# Disable CUDA repo using the appropriate manager and version lock glibc to
-# the current version from the `nvidia/cuda` images
+# Disable CUDA repo using the appropriate manager to prevent cross CUDA version
+# updates seen on 10.1 with 10.2 libraries
+# CentOS 7 - version lock glibc to the current version from the `nvidia/cuda`
+# CentOS 8 - install glibc langpack
 RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
       yum-config-manager --disable cuda \
       && yum -y install yum-versionlock \
@@ -60,9 +62,8 @@ RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
     elif [ "${LINUX_VER}" == "centos8" ] ; then \
       dnf install -y \
         'dnf-command(config-manager)' \
-        'dnf-command(versionlock)' \
-      && dnf config-manager --set-disabled cuda \
-      && dnf versionlock glibc glibc-common glibc-devel glibc-headers ; \
+        glibc-langpack-en \
+      && dnf config-manager --set-disabled cuda ; \
     fi
 
 # Update and add pkgs for CentOS

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -51,15 +51,18 @@ RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
       echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'ubuntu16.04' or 'ubuntu18.04'\n\n"; \
     fi
 
-# Disable CUDA repo using the appropriate manager
-#   Also add langpack for locale in CentOS 8
+# Disable CUDA repo using the appropriate manager and version lock glibc to
+# the current version from the `nvidia/cuda` images
 RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
-      yum-config-manager --disable cuda ; \
+      yum-config-manager --disable cuda \
+      && yum -y install yum-versionlock \
+      && yum versionlock glibc glibc-common glibc-devel glibc-headers ; \
     elif [ "${LINUX_VER}" == "centos8" ] ; then \
       dnf install -y \
         'dnf-command(config-manager)' \
-        glibc-langpack-en \
-      && dnf config-manager --set-disabled cuda ; \
+        'dnf-command(versionlock)' \
+      && dnf config-manager --set-disabled cuda \
+      && dnf versionlock glibc glibc-common glibc-devel glibc-headers ; \
     fi
 
 # Update and add pkgs for CentOS

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -53,12 +53,9 @@ RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
 
 # Disable CUDA repo using the appropriate manager to prevent cross CUDA version
 # updates seen on 10.1 with 10.2 libraries
-# CentOS 7 - version lock glibc to the current version from the `nvidia/cuda`
 # CentOS 8 - install glibc langpack
 RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
-      yum-config-manager --disable cuda \
-      && yum -y install yum-versionlock \
-      && yum versionlock glibc glibc-common glibc-devel glibc-headers ; \
+      yum-config-manager --disable cuda ; \
     elif [ "${LINUX_VER}" == "centos8" ] ; then \
       dnf install -y \
         'dnf-command(config-manager)' \

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -49,12 +49,9 @@ RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
 
 # Disable CUDA repo using the appropriate manager to prevent cross CUDA version
 # updates seen on 10.1 with 10.2 libraries
-# CentOS 7 - version lock glibc to the current version from the `nvidia/cuda`
 # CentOS 8 - install glibc langpack
 RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
-      yum-config-manager --disable cuda \
-      && yum -y install yum-versionlock \
-      && yum versionlock glibc glibc-common glibc-devel glibc-headers ; \
+      yum-config-manager --disable cuda ; \
     elif [ "${LINUX_VER}" == "centos8" ] ; then \
       dnf install -y \
         'dnf-command(config-manager)' \

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -47,15 +47,18 @@ RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
       echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'ubuntu16.04' or 'ubuntu18.04'\n\n"; \
     fi
 
-# Disable CUDA repo using the appropriate manager
-#   Also add langpack for locale in CentOS 8
+# Disable CUDA repo using the appropriate manager and version lock glibc to
+# the current version from the `nvidia/cuda` images
 RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
-      yum-config-manager --disable cuda ; \
+      yum-config-manager --disable cuda \
+      && yum -y install yum-versionlock \
+      && yum versionlock glibc glibc-common glibc-devel glibc-headers ; \
     elif [ "${LINUX_VER}" == "centos8" ] ; then \
       dnf install -y \
         'dnf-command(config-manager)' \
-        glibc-langpack-en \
-      && dnf config-manager --set-disabled cuda ; \
+        'dnf-command(versionlock)' \
+      && dnf config-manager --set-disabled cuda \
+      && dnf versionlock glibc glibc-common glibc-devel glibc-headers ; \
     fi
 
 # Update and add pkgs for CentOS

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -47,8 +47,10 @@ RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
       echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'ubuntu16.04' or 'ubuntu18.04'\n\n"; \
     fi
 
-# Disable CUDA repo using the appropriate manager and version lock glibc to
-# the current version from the `nvidia/cuda` images
+# Disable CUDA repo using the appropriate manager to prevent cross CUDA version
+# updates seen on 10.1 with 10.2 libraries
+# CentOS 7 - version lock glibc to the current version from the `nvidia/cuda`
+# CentOS 8 - install glibc langpack
 RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
       yum-config-manager --disable cuda \
       && yum -y install yum-versionlock \
@@ -56,9 +58,8 @@ RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
     elif [ "${LINUX_VER}" == "centos8" ] ; then \
       dnf install -y \
         'dnf-command(config-manager)' \
-        'dnf-command(versionlock)' \
-      && dnf config-manager --set-disabled cuda \
-      && dnf versionlock glibc glibc-common glibc-devel glibc-headers ; \
+        glibc-langpack-en \
+      && dnf config-manager --set-disabled cuda ; \
     fi
 
 # Update and add pkgs for CentOS

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -52,23 +52,20 @@ channels: \n\
       && cat /opt/conda/.condarc ; \
     fi
 
-# Install gcc7 - 7.5.0 to bring build stack in line with conda-forge
+# Install gcc7 - 7.5.0 for CUDA 10.X builds and install latest
+#  'libstdc++6' to be compatible with conda-forge dependencies
+#  for from-source builds, see PR #159
 RUN apt-get update \
     && apt-get install -y software-properties-common \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     && apt-get update \
-    && apt-get install -y gcc-7 g++-7 \
+    && apt-get install -y gcc-7 g++-7 libstdc++6 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7 \
     && update-alternatives --set gcc /usr/bin/gcc-7 \
     && update-alternatives --set g++ /usr/bin/g++-7 \
     && gcc --version \
     && g++ --version
-
-# Install latest version of 'libstdc++6' on 'ubuntu18.04' - see PR #159
-RUN if [ "${LINUX_VER}" == "ubuntu18.04" ] ; then \
-      apt-get upgrade -y libstdc++6 ; \
-    fi
 
 # Update and add pkgs for gpuci builds
 RUN apt-get update -y --fix-missing \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -65,6 +65,11 @@ RUN apt-get update \
     && gcc --version \
     && g++ --version
 
+# Install latest version of 'libstdc++6' on 'ubuntu18.04' - see PR #159
+RUN if [ "${LINUX_VER}" == "ubuntu18.04" ] ; then \
+      apt-get upgrade -y libstdc++6 ; \
+    fi
+
 # Update and add pkgs for gpuci builds
 RUN apt-get update -y --fix-missing \
     && apt-get -qq install apt-utils -y --no-install-recommends \


### PR DESCRIPTION
- [x] Update centos gcc7 build to include gcc9 `libstdc++.so`
- [x] ~Update `ubuntu18.04` devel builds for `rapidsai` to include and upgrade for `libstdc++6` pkg to upgrade to `10.1`~ - Done in #160

After #153 building with system gcc7 compilers and the conda gcc9 runtime libraries causes an ABI mismatch and prevents from-source builds in the `rapidsai/rapidsai-core-dev` containers. Updating the gcc7 tarball for centos 7/8 and upgrading `libstdc++6` pkg on `ubuntu18.04` will solve this issue for those systems.

`ubuntu16.04`, `ubuntu20.04` are not impacted as 16.04 has version `9.3` already and 20.04 has version `10.2`

We will need to create a RAPIDS Notice for developers to update them on this change for from-source builds with conda dependencies