### PR TITLE
Install libstdc++6

### DIFF
--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -52,12 +52,14 @@ channels: \n\
       && cat /opt/conda/.condarc ; \
     fi
 
-# Install gcc7 - 7.5.0 to bring build stack in line with conda-forge
+# Install gcc7 - 7.5.0 for CUDA 10.X builds and install latest
+# 'libstdc++6' to be compatible with conda-forge dependencies
+# for from-source builds
 RUN apt-get update \
     && apt-get install -y software-properties-common \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     && apt-get update \
-    && apt-get install -y gcc-7 g++-7 \
+    && apt-get install -y gcc-7 g++-7 libstdc++6 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7 \
     && update-alternatives --set gcc /usr/bin/gcc-7 \


### PR DESCRIPTION
- [x] Update `ubuntu18.04` devel builds for `rapidsai` to include and upgrade for `libstdc++6` pkg to upgrade to `10.1`

After #153 building with system gcc7 compilers and the conda gcc9 runtime libraries causes an ABI mismatch and prevents from-source builds in the `rapidsai/rapidsai-core-dev` containers. Upgrading `libstdc++6` pkg on `ubuntu18.04` will solve this issue.

`ubuntu16.04`, `ubuntu20.04` are not impacted as 16.04 has version `9.3` already and 20.04 has version `10.2`

We will need to create a RAPIDS Notice for developers to update them on this change for from-source builds with conda dependencies

Follow-up to split #159 