### PR TITLE
FIX Update `conda clean` to remove all pkgs

### DIFF
--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -89,14 +89,17 @@ RUN wget --quiet ${MINICONDA_URL} -O /miniconda.sh \
     && /bin/bash /miniconda.sh -b -p /opt/conda \
     && rm -f /miniconda.sh \
     && echo "conda ${CONDA_VER}" >> /opt/conda/conda-meta/pinned \
-    && /opt/conda/bin/conda clean -tipsy \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
     && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
     && echo "conda activate base" >> ~/.bashrc \
     && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/skel/.bashrc \
     && echo "auto_update_conda: False" >> /opt/conda/.condarc \
-    && chmod -R ugo+w /opt/conda \
     && ln -s /opt/conda /conda
+
+# Clean up conda and set permissions for all users
+RUN chmod -R ugo+w /opt/conda\
+    && /opt/conda/bin/conda clean -tipy \
+    && chmod -R ugo+w /opt/conda
 
 # Install tini for init
 RUN wget --quiet ${TINI_URL} -O /usr/bin/tini \

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -97,7 +97,7 @@ RUN wget --quiet ${MINICONDA_URL} -O /miniconda.sh \
     && ln -s /opt/conda /conda
 
 # Clean up conda and set permissions for all users
-RUN chmod -R ugo+w /opt/conda\
+RUN chmod -R ugo+w /opt/conda \
     && /opt/conda/bin/conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -96,7 +96,7 @@ RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
 RUN conda install -k -y tini
 
 # Clean up conda and set permissions for all users
-RUN /opt/conda/bin/conda clean -tipsy \
+RUN /opt/conda/bin/conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
 ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -96,7 +96,7 @@ RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
 RUN conda install -k -y tini
 
 # Clean up conda and set permissions for all users
-RUN chmod -R ugo+w /opt/conda\
+RUN chmod -R ugo+w /opt/conda \
     && /opt/conda/bin/conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -96,7 +96,8 @@ RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
 RUN conda install -k -y tini
 
 # Clean up conda and set permissions for all users
-RUN /opt/conda/bin/conda clean -tipy \
+RUN chmod -R ugo+w /opt/conda\
+    && /opt/conda/bin/conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
 ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -81,7 +81,8 @@ RUN if [ "${IMAGE_TYPE}" == "runtime" ] ; then \
     fi
 
 # Clean up pkgs to reduce image size
-RUN conda clean -tipsy \
+RUN conda clean -tipy \
+    && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
 ENTRYPOINT [ "/usr/bin/tini", "--" ]

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -82,6 +82,7 @@ RUN if [ "${IMAGE_TYPE}" == "runtime" ] ; then \
 
 # Clean up pkgs to reduce image size
 RUN conda clean -tipy \
+    && conda activate rapids \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -81,8 +81,7 @@ RUN if [ "${IMAGE_TYPE}" == "runtime" ] ; then \
     fi
 
 # Clean up pkgs to reduce image size
-RUN conda clean -tipy \
-    && conda activate rapids \
+RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -120,8 +120,7 @@ RUN gpuci_retry wget --quiet ${CENTOS7_GCC7_URL} -O /gcc7.tgz \
     && rm -f /gcc7.tgz
 
 # Clean up pkgs to reduce image size and chmod for all users
-RUN conda clean -tipy \
-    && conda activate rapids \
+RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -121,6 +121,7 @@ RUN gpuci_retry wget --quiet ${CENTOS7_GCC7_URL} -O /gcc7.tgz \
 
 # Clean up pkgs to reduce image size and chmod for all users
 RUN conda clean -tipy \
+    && conda activate rapids \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -120,7 +120,8 @@ RUN gpuci_retry wget --quiet ${CENTOS7_GCC7_URL} -O /gcc7.tgz \
     && rm -f /gcc7.tgz
 
 # Clean up pkgs to reduce image size and chmod for all users
-RUN conda clean -tipsy \
+RUN conda clean -tipy \
+    && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
 ENTRYPOINT [ "/usr/bin/tini", "--" ]

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -134,6 +134,7 @@ RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
 
 # Clean up pkgs to reduce image size and chmod for all users
 RUN conda clean -tipy \
+    && conda activate rapids \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -133,8 +133,7 @@ RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
       rapids-notebook-env=${RAPIDS_VER}
 
 # Clean up pkgs to reduce image size and chmod for all users
-RUN conda clean -tipy \
-    && conda activate rapids \
+RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -133,7 +133,8 @@ RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
       rapids-notebook-env=${RAPIDS_VER}
 
 # Clean up pkgs to reduce image size and chmod for all users
-RUN conda clean -tipsy \
+RUN conda clean -tipy \
+    && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
 ENTRYPOINT [ "/usr/bin/tini", "--" ]


### PR DESCRIPTION
## Overview

Our current docker images do not remove all cached conda packages despite using `conda clean -tipy` which has worked in the past. This has resulted in an extra 4-7GB of uncompressed data being added to our `gpuci/rapidsai` images. Which in turn makes our `rapidsai/rapidsai-*` images much larger than needed.

The fixes in this PR addresses the issue and reduces the docker images sizes by several GBs.

It appears the issue stems from a permissions error where after `chmod -R ugo+w /opt/conda` is run, we are able to remove all pkgs.

## Sample image sizes

`gpuci/rapidsai` image tag | Current image size | New image size | Size reduction
--- | --- | --- | ---
`0.18-cuda11.0-base-ubuntu16.04-py3.7` | 6.6GB | 4.47GB | 2.13GB
`0.18-cuda11.0-runtime-ubuntu16.04-py3.7` | 11.2GB | 6.79GB | 4.41GB
`0.18-cuda11.0-devel-ubuntu16.04-py3.7` | 18.5GB | 11.5GB | 7GB