### PR TITLE
ENH Add arm64/aarch64 SBSA support for CUDA 11.0+

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,22 @@ pipeline {
             }
           }
         }
+        stage('gpuCI/build/miniforge-cuda-arm64') {
+          steps {
+            retry(1) {
+              build(
+                job: 'gpuci/gpuci-build-environment-jobs/miniforge-cuda-arm64',
+                wait: true,
+                propagate: true,
+                parameters: [
+                  string(name: 'GIT_URL', value: env.GIT_URL),
+                  string(name: 'PR_ID', value: (env.CHANGE_ID == null) ? 'BRANCH' : env.CHANGE_ID),
+                  string(name: 'COMMIT_HASH', value: (env.CHANGE_ID == null) ? env.GIT_BRANCH : 'origin/pr/'+env.CHANGE_ID+'/merge')
+                ]
+              )
+            }
+          }
+        }
       }
     }
     stage('gpuCI/build/miniconda-cuda-driver') {

--- a/ci/axis/miniforge-cuda-arm64.yml
+++ b/ci/axis/miniforge-cuda-arm64.yml
@@ -14,7 +14,7 @@ DOCKER_FILE:
 # so it can be used in all images within gpuCI; to make parsing easier we add
 # it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
-  - 11.2.0
+  - 11.2.1
   - 11.1.1
   - 11.0.3
 

--- a/ci/axis/miniforge-cuda-arm64.yml
+++ b/ci/axis/miniforge-cuda-arm64.yml
@@ -29,3 +29,7 @@ LINUX_VER:
   - centos8
 
 exclude:
+  - CUDA_VER: 11.1.1
+    LINUX_VER: ubuntu20.04
+  - CUDA_VER: 11.0.3
+    LINUX_VER: ubuntu20.04

--- a/ci/axis/miniforge-cuda-arm64.yml
+++ b/ci/axis/miniforge-cuda-arm64.yml
@@ -1,0 +1,31 @@
+BUILD_IMAGE:
+  - gpuci/miniforge-cuda-arm64
+
+FROM_IMAGE:
+  - nvidia/cuda-arm64
+
+IMAGE_NAME:
+  - miniforge-cuda-arm64
+
+DOCKER_FILE:
+  - Dockerfile
+
+# CUDA_VERSION is not defined for CUDA 11 images - this defines it in this image
+# so it can be used in all images within gpuCI; to make parsing easier we add
+# it to the existing CUDA_VER var and remove the patch version in run script
+CUDA_VER:
+  - 11.2.0
+  - 11.1.1
+  - 11.0.3
+
+IMAGE_TYPE:
+  - base
+  - runtime
+  - devel
+
+LINUX_VER:
+  - ubuntu18.04
+  - ubuntu20.04
+  - centos8
+
+exclude:

--- a/ci/axis/miniforge-cuda.yml
+++ b/ci/axis/miniforge-cuda.yml
@@ -10,9 +10,6 @@ IMAGE_NAME:
 DOCKER_FILE:
   - Dockerfile
 
-ARCH_TYPE:
-  - x86_64
-
 # CUDA_VERSION is not defined for CUDA 11 images - this defines it in this image
 # so it can be used in all images within gpuCI; to make parsing easier we add
 # it to the existing CUDA_VER var and remove the patch version in run script

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -35,7 +35,7 @@ else
   BUILD_REPO=`echo $BUILD_IMAGE | tr '/' ' ' | awk '{ print $2 }'`
   BUILD_IMAGE="gpucitesting/${BUILD_REPO}-pr${PR_ID}"
   # Check if FROM_IMAGE to see if it is a root build
-  if [[ "$FROM_IMAGE" == "gpuci/cuda" || "$FROM_IMAGE" == "nvidia/cuda" ]] ; then
+  if [[ "$FROM_IMAGE" == "gpuci/cuda" || "$FROM_IMAGE" == "nvidia/cuda" || "$FROM_IMAGE" == "nvidia/cuda-arm64" ]] ; then
     echo ">> No need to update FROM_IMAGE, using external image..."
   else
     echo ">> Need to update FROM_IMAGE to use PR's version for testing..."

--- a/miniforge-cuda-arm64/Dockerfile
+++ b/miniforge-cuda-arm64/Dockerfile
@@ -1,0 +1,102 @@
+ARG FROM_IMAGE=nvidia/cuda-arm64
+ARG FULL_CUDA_VER=11.2.0
+ARG IMAGE_TYPE=base
+ARG LINUX_VER=ubuntu20.04
+FROM ${FROM_IMAGE}:${FULL_CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}
+
+# Pull argument from build args
+ARG FULL_CUDA_VER
+ARG LINUX_VER
+
+# Define versions and download locations
+ARG ARCH_TYPE=aarch64
+ARG CONDA_VER=4.8.3-5
+ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${CONDA_VER}/Miniforge3-${CONDA_VER}-Linux-${ARCH_TYPE}.sh
+
+# Set environment
+ENV PATH=/opt/conda/bin:${PATH}
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set CUDA_VERSION as in some 'nvidia/cuda' images this is not set
+## A lot of scripts and conda recipes depend on this env var
+ENV CUDA_VERSION=${FULL_CUDA_VER}
+
+# Enables "source activate conda"
+SHELL ["/bin/bash", "-c"]
+
+# Update and add pkgs for Ubuntu, also generate locales for 'en_US.UTF-8'
+RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
+      apt-get update \
+      && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        bzip2 \
+        ca-certificates \
+        curl \
+        git \
+        locales \
+        patch \
+        tzdata \
+        unzip \
+        wget \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/* \
+      && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+      && locale-gen ; \
+    else \
+      echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'ubuntu16.04' or 'ubuntu18.04'\n\n"; \
+    fi
+
+# Disable CUDA repo using the appropriate manager to prevent cross CUDA version
+# updates seen on 10.1 with 10.2 libraries
+# CentOS 8 - install glibc langpack
+RUN if [ "${LINUX_VER}" == "centos8" ] ; then \
+      dnf install -y \
+        'dnf-command(config-manager)' \
+        glibc-langpack-en \
+      && dnf config-manager --set-disabled cuda ; \
+    fi
+
+# Update and add pkgs for CentOS
+RUN if [ "${LINUX_VER:0:6}" == "centos" ] ; then \
+      yum -y update \
+      && yum remove -y bind-license \
+      && yum -y install \
+        autoconf \
+        automake \
+        bzip2 \
+        ca-certificates \
+        curl \
+        git \
+        make \
+        patch \
+        unzip \
+        wget \
+        which \
+      && yum clean all ; \
+    else \
+      echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'centos7' or 'centos8'\n\n"; \
+    fi
+
+# Install miniforge and configure
+RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
+    && /bin/bash /miniforge.sh -b -p /opt/conda \
+    && rm -f /miniforge.sh \
+    && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
+    && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
+    && echo "conda activate base" >> ~/.bashrc \
+    && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/skel/.bashrc \
+    && echo "auto_update_conda: False" >> /opt/conda/.condarc \
+    && echo "ssl_verify: False" >> /opt/conda/.condarc \
+    && ln -s /opt/conda /conda
+
+# Install tini for init
+RUN conda install -k -y tini
+
+# Clean up conda and set permissions for all users
+RUN chmod -R ugo+w /opt/conda \
+    && /opt/conda/bin/conda clean -tipy \
+    && chmod -R ugo+w /opt/conda
+
+ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
Based off of `nvidia/cuda-arm64` images add a `miniforge` environment and create images for CUDA 11.0+

## Infrastructure work
- [x] Create AMIs for arm64/aarch64 instances (done in rapidsai/gpuci-mgmt#16)
- [x] Update gpuCI to use `m6gd.xlarge` instances
- [x] Setup AMI cloud config in gpuCI (labels `cpu-arm64` or `cpu-aarch64`)

## Image build work
- [x] Create new SBSA Jenkins job and Jenkinsfile changes to use job
- [ ] Update repo docs for new images
- [ ] Test builds and confirm success