### PR TITLE
ENH Add GDS header to rapidsai devel images

### DIFF
--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -93,7 +93,8 @@ RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
     && ln -s /opt/conda /conda
 
 # Install tini for init
-RUN conda install -k -y tini
+RUN conda install -k -y tini \
+    || conda install -k -y tini
 
 # Clean up conda and set permissions for all users
 RUN chmod -R ugo+w /opt/conda \

--- a/rapidsai/devel-centos7.Dockerfile
+++ b/rapidsai/devel-centos7.Dockerfile
@@ -124,5 +124,8 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
+# Add GDS header cufile.h to image
+COPY cufile.h /usr/local/cuda/targets/x86_64-linux/lib/cufile.h
+
 ENTRYPOINT [ "/usr/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -137,5 +137,8 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
+# Add GDS header cufile.h to image
+COPY cufile.h /usr/local/cuda/targets/x86_64-linux/lib/cufile.h
+
 ENTRYPOINT [ "/usr/bin/tini", "--" ]
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
Used for testing and builds for GDS support that is coming with rapidsai/cudf#7444

- [x] Upload GDS header files to S3
- [x] Update gpuCI job to sync from S3 where the GDS files are stored so this `COPY` command can work
- [x] Test the changes work and are located in the proper location according to these [docs](https://docs.nvidia.com/gpudirect-storage/troubleshooting-guide/index.html#gds-lib-tools)