### PR TITLE
ENH Incorporate upstream CUDA 11+ version changes

### DIFF
--- a/ci/axis/miniconda-cuda-driver.yml
+++ b/ci/axis/miniconda-cuda-driver.yml
@@ -11,6 +11,7 @@ DOCKER_FILE:
   - Dockerfile
 
 CUDA_VER:
+  - 11.2
   - 11.1
   - 11.0
   - 10.2

--- a/ci/axis/miniconda-cuda-driver.yml
+++ b/ci/axis/miniconda-cuda-driver.yml
@@ -30,6 +30,7 @@ DRIVER_VER:
   - 440
   - 450
   - 455
+  - 460
 
 exclude:
   - CUDA_VER: 10.0
@@ -40,6 +41,8 @@ exclude:
     DRIVER_VER: 450
   - CUDA_VER: 10.0
     DRIVER_VER: 455
+  - CUDA_VER: 10.0
+    DRIVER_VER: 460
   - CUDA_VER: 10.1
     DRIVER_VER: 410
   - CUDA_VER: 10.1
@@ -48,6 +51,8 @@ exclude:
     DRIVER_VER: 450
   - CUDA_VER: 10.1
     DRIVER_VER: 455
+  - CUDA_VER: 10.1
+    DRIVER_VER: 460
   - CUDA_VER: 10.2
     DRIVER_VER: 410
   - CUDA_VER: 10.2
@@ -56,6 +61,8 @@ exclude:
     DRIVER_VER: 450
   - CUDA_VER: 10.2
     DRIVER_VER: 455
+  - CUDA_VER: 10.2
+    DRIVER_VER: 460
   - CUDA_VER: 11.0
     DRIVER_VER: 410
   - CUDA_VER: 11.0
@@ -64,6 +71,8 @@ exclude:
     DRIVER_VER: 440
   - CUDA_VER: 11.0
     DRIVER_VER: 455
+  - CUDA_VER: 11.0
+    DRIVER_VER: 460
   - CUDA_VER: 11.1
     DRIVER_VER: 410
   - CUDA_VER: 11.1
@@ -72,3 +81,15 @@ exclude:
     DRIVER_VER: 440
   - CUDA_VER: 11.1
     DRIVER_VER: 450
+  - CUDA_VER: 11.1
+    DRIVER_VER: 460
+  - CUDA_VER: 11.2
+    DRIVER_VER: 410
+  - CUDA_VER: 11.2
+    DRIVER_VER: 418
+  - CUDA_VER: 11.2
+    DRIVER_VER: 440
+  - CUDA_VER: 11.2
+    DRIVER_VER: 450
+  - CUDA_VER: 11.2
+    DRIVER_VER: 455

--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -59,6 +59,8 @@ exclude:
     LINUX_VER: centos8
   - CUDA_VER: 10.0.130
     LINUX_VER: centos8
+  - CUDA_VER: 11.2.2
+    LINUX_VER: centos7
 # Uncomment below and `- gpuci/cuda` above to build using gpuCI CUDA images
 # NOTE: gpuci/cuda:11.0* is 11.0.194 and would need CUDA_VER to change on revert
 #  - CUDA_VER: 9.0.176

--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -15,8 +15,9 @@ DOCKER_FILE:
 #   so it can be used in all images within gpuCI; to make parsing easier we add
 #   it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
-  - 11.1.74
-  - 11.0.221
+  - 11.2.2
+  - 11.1.1
+  - 11.0.3
   - 10.2.89
   - 10.1.243
   - 10.0.130

--- a/ci/axis/miniforge-cuda.yml
+++ b/ci/axis/miniforge-cuda.yml
@@ -17,8 +17,9 @@ ARCH_TYPE:
 # so it can be used in all images within gpuCI; to make parsing easier we add
 # it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
-  - 11.1.74
-  - 11.0.221
+  - 11.2.2
+  - 11.1.1
+  - 11.0.3
   - 10.2.89
   - 10.1.243
   - 10.0.130

--- a/ci/axis/miniforge-cuda.yml
+++ b/ci/axis/miniforge-cuda.yml
@@ -61,3 +61,5 @@ exclude:
     LINUX_VER: centos8
   - CUDA_VER: 10.0.130
     LINUX_VER: centos8
+  - CUDA_VER: 11.2.2
+    LINUX_VER: centos7

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -27,6 +27,17 @@ if [ `tr -dc '.' <<<"$CUDA_VER" | awk '{ print length }'` -eq 2 ] ; then
   gpuci_logger "Detected patch version in CUDA_VER - Set CUDA_VER='$CUDA_VER' and FULL_CUDA_VER='$FULL_CUDA_VER'"
 fi
 BUILD_TAG="${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}"
+# Check if CUDA 11+, if so include patch version in CUDA_VER for nvidia/cuda & gpuci/cuda FROM images
+if [[ "${CUDA_VER:0:2}" == "10" || "${CUDA_VER:0:2}" == "9" ]] ; then
+  echo "Detected CUDA 9/10, no need to update CUDA_VER..."
+else
+  echo "Detected CUDA 11+, checking FROM_IMAGE..."
+  if [[ "$FROM_IMAGE" == "gpuci/cuda" || "$FROM_IMAGE" == "nvidia/cuda" ]] ; then
+    echo ">> Need to update CUDA_VER to pull correct external image..."
+    CUDA_VER=FULL_CUDA_VER
+    echo ">> CUDA_VER is now set to '$CUDA_VER'..."
+  fi
+fi
 # Check if PR build and modify BUILD_IMAGE and BUILD_TAG
 if [ "$PR_ID" == "BRANCH" ] ; then
   echo "PR_ID is set to 'BRANCH', skipping PR updates"

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -28,7 +28,7 @@ if [ `tr -dc '.' <<<"$CUDA_VER" | awk '{ print length }'` -eq 2 ] ; then
 fi
 BUILD_TAG="${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}"
 # Check if CUDA 11+, if so include patch version in CUDA_VER for nvidia/cuda & gpuci/cuda FROM images
-if [[ "${CUDA_VER:0:2}" == "10" || "${CUDA_VER:0:2}" == "9" ]] ; then
+if [[ "${CUDA_VER:0:2}" == "10" || "${CUDA_VER:0:1}" == "9" ]] ; then
   echo "Detected CUDA 9/10, no need to update CUDA_VER..."
 else
   echo "Detected CUDA 11+, checking FROM_IMAGE..."

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -33,9 +33,11 @@ if [[ "${CUDA_VER:0:2}" == "10" || "${CUDA_VER:0:2}" == "9" ]] ; then
 else
   echo "Detected CUDA 11+, checking FROM_IMAGE..."
   if [[ "$FROM_IMAGE" == "gpuci/cuda" || "$FROM_IMAGE" == "nvidia/cuda" ]] ; then
-    echo ">> Need to update CUDA_VER to pull correct external image..."
+    echo ">> FROM_IMAGE is an external image, need to update CUDA_VER to pull correct external image..."
     CUDA_VER=$FULL_CUDA_VER
     echo ">> CUDA_VER is now set to '$CUDA_VER'..."
+  else
+    echo ">> FROM_IMAGE not an external image, no need to update CUDA_VER..."
   fi
 fi
 # Check if PR build and modify BUILD_IMAGE and BUILD_TAG

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -34,7 +34,7 @@ else
   echo "Detected CUDA 11+, checking FROM_IMAGE..."
   if [[ "$FROM_IMAGE" == "gpuci/cuda" || "$FROM_IMAGE" == "nvidia/cuda" ]] ; then
     echo ">> Need to update CUDA_VER to pull correct external image..."
-    CUDA_VER=FULL_CUDA_VER
+    CUDA_VER=$FULL_CUDA_VER
     echo ">> CUDA_VER is now set to '$CUDA_VER'..."
   fi
 fi


### PR DESCRIPTION
Recently `nvidia/cuda` has changed it's [tags]() to include the patch version as well. To pull CUDA 11.2 and newer images we need to update our builds to use this patch version

While `nvidia/cuda` is incorporating the patch version into tags, our plan is to not incorporate them in our images to maintain compatibility with existing scripts and services