### PR TITLE
Remove DEBIAN_FRONTEND environment variable

### DIFF
--- a/miniconda-cuda-driver/Dockerfile
+++ b/miniconda-cuda-driver/Dockerfile
@@ -22,7 +22,7 @@ RUN source activate base \
 
 # Update and add pkgs
 RUN apt-get update -q \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get -qq install apt-utils -y --no-install-recommends \
       nvidia-${DRIVER_VER}-dev \
       libcuda1-${DRIVER_VER} \
     && apt-get clean \

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -30,7 +30,7 @@ SHELL ["/bin/bash", "-c"]
 RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
       apt-get update -q \
       && apt-get upgrade -y \
-      && apt-get install -y --no-install-recommends \
+      && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         autoconf \
         automake \
         bzip2 \

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -18,7 +18,6 @@ ARG TINI_URL=https://github.com/krallin/tini/releases/download/${TINI_VER}/tini
 ENV CONDA_DIR=/opt/conda
 ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LANGUAGE=en_US:en
 ENV PATH=${CONDA_DIR}/bin:${PATH}
-ENV DEBIAN_FRONTEND=noninteractive
 
 # Set CUDA_VERSION as in some 'nvidia/cuda' images this is not set
 ## A lot of scripts and conda recipes depend on this env var

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -15,7 +15,6 @@ ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${C
 
 # Set environment
 ENV PATH=/opt/conda/bin:${PATH}
-ENV DEBIAN_FRONTEND=noninteractive
 
 # Set CUDA_VERSION as in some 'nvidia/cuda' images this is not set
 ## A lot of scripts and conda recipes depend on this env var

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -26,7 +26,7 @@ SHELL ["/bin/bash", "-c"]
 # Update and add pkgs for Ubuntu, also generate locales for 'en_US.UTF-8'
 RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
       apt-get update \
-      && apt-get install -y --no-install-recommends \
+      && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         autoconf \
         automake \
         bzip2 \

--- a/rapidsai-driver/Dockerfile
+++ b/rapidsai-driver/Dockerfile
@@ -12,7 +12,7 @@ ARG DRIVER_VER="440"
 
 # Update and add pkgs
 RUN apt-get update -q \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get -qq install apt-utils -y --no-install-recommends \
       nvidia-${DRIVER_VER}-dev \
       libcuda1-${DRIVER_VER} \
     && apt-get clean \


### PR DESCRIPTION
This PR removes the `DEBIAN_FRONTEND=noninteractive` environment variable from the `gpuci-build-environment` images. These variables ultimately get inherited by our `rapidsai/docker` images, some of which _are_ intended to be interactive containers, so it seems contradictory to have this variable set to `noninteractive`. Setting `DEBIAN_FRONTEND=noninteractive` changes the default behavior that people expect from commands like `apt-get install` and can therefore cause some confusion for our users.

Alternatively, we could unset the variable in the `rapidsai/docker` images, but this seems cleaner unless there is a reason it's needed here.