### PR TITLE
ENH Add CUDA-L4T support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,6 +89,22 @@ pipeline {
         }
       }
     }
+    stage('gpuCI/build/rapidsai-l4t') {
+      steps {
+        retry(1) {
+          build(
+            job: 'gpuci/gpuci-build-environment-jobs/rapidsai-l4t',
+            wait: true,
+            propagate: true,
+            parameters: [
+              string(name: 'GIT_URL', value: env.GIT_URL),
+              string(name: 'PR_ID', value: (env.CHANGE_ID == null) ? 'BRANCH' : env.CHANGE_ID),
+              string(name: 'COMMIT_HASH', value: (env.CHANGE_ID == null) ? env.GIT_BRANCH : 'origin/pr/'+env.CHANGE_ID+'/merge')
+            ]
+          )
+        }
+      }
+    }
     stage('gpuCI/build/rapidsai-driver') {
       steps {
         retry(1) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,22 @@ pipeline {
             }
           }
         }
+        stage('gpuCI/build/miniforge-cuda-l4t') {
+          steps {
+            retry(1) {
+              build(
+                job: 'gpuci/gpuci-build-environment-jobs/miniforge-cuda-l4t',
+                wait: true,
+                propagate: true,
+                parameters: [
+                  string(name: 'GIT_URL', value: env.GIT_URL),
+                  string(name: 'PR_ID', value: (env.CHANGE_ID == null) ? 'BRANCH' : env.CHANGE_ID),
+                  string(name: 'COMMIT_HASH', value: (env.CHANGE_ID == null) ? env.GIT_BRANCH : 'origin/pr/'+env.CHANGE_ID+'/merge')
+                ]
+              )
+            }
+          }
+        }
       }
     }
     stage('gpuCI/build/miniconda-cuda-driver') {

--- a/ci/axis/miniforge-cuda-l4t.yml
+++ b/ci/axis/miniforge-cuda-l4t.yml
@@ -1,0 +1,26 @@
+BUILD_IMAGE:
+  - gpuci/miniforge-cuda-l4t
+
+FROM_IMAGE:
+  - gpuci/cuda-l4t
+
+IMAGE_NAME:
+  - miniforge-cuda-l4t
+
+DOCKER_FILE:
+  - Dockerfile
+
+# CUDA_VERSION is not defined for CUDA 11 images - this defines it in this image
+# so it can be used in all images within gpuCI; to make parsing easier we add
+# it to the existing CUDA_VER var and remove the patch version in run script
+CUDA_VER:
+  - 10.2.89
+
+IMAGE_TYPE:
+  - runtime
+  - devel
+
+LINUX_VER:
+  - ubuntu18.04
+
+exclude:

--- a/ci/axis/rapidsai-l4t.yml
+++ b/ci/axis/rapidsai-l4t.yml
@@ -1,0 +1,36 @@
+BUILD_IMAGE:
+  - gpuci/rapidsai-l4t
+
+FROM_IMAGE:
+  - gpuci/miniforge-cuda-l4t
+
+IMAGE_NAME:
+  - rapidsai-l4t
+
+DOCKER_FILE:
+  - Dockerfile
+
+RAPIDS_VER:
+  - 0.19
+
+RAPIDS_CHANNEL:
+  - rapidsai-nightly
+
+CUDA_VER:
+  - 10.2
+
+IMAGE_TYPE:
+  - runtime
+  - devel
+
+LINUX_VER:
+  - ubuntu18.04
+
+PYTHON_VER:
+  - 3.7
+  - 3.8
+
+BUILD_STACK_VER:
+  - 9.3.0
+
+exclude:

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -48,7 +48,7 @@ else
   BUILD_REPO=`echo $BUILD_IMAGE | tr '/' ' ' | awk '{ print $2 }'`
   BUILD_IMAGE="gpucitesting/${BUILD_REPO}-pr${PR_ID}"
   # Check if FROM_IMAGE to see if it is a root build
-  if [[ "$FROM_IMAGE" == "gpuci/cuda" || "$FROM_IMAGE" == "nvidia/cuda" ]] ; then
+  if [[ "$FROM_IMAGE" == "gpuci/cuda" || "$FROM_IMAGE" == "nvidia/cuda" || "$FROM_IMAGE" == "gpuci/cuda-l4t" ]] ; then
     echo ">> No need to update FROM_IMAGE, using external image..."
   else
     echo ">> Need to update FROM_IMAGE to use PR's version for testing..."

--- a/miniforge-cuda-l4t/Dockerfile
+++ b/miniforge-cuda-l4t/Dockerfile
@@ -93,7 +93,8 @@ RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
     && ln -s /opt/conda /conda
 
 # Install tini for init
-RUN conda install -k -y tini
+RUN conda install -k -y tini \
+    || conda install -k -y tini
 
 RUN chmod -R ugo+w /opt/conda
 

--- a/miniforge-cuda-l4t/Dockerfile
+++ b/miniforge-cuda-l4t/Dockerfile
@@ -1,0 +1,102 @@
+ARG FROM_IMAGE=gpuci/cuda-l4t
+ARG CUDA_VER=10.2
+ARG IMAGE_TYPE=devel
+ARG LINUX_VER=ubuntu18.04
+FROM ${FROM_IMAGE}:${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}
+
+# Pull argument from build args
+ARG FULL_CUDA_VER
+ARG LINUX_VER
+
+# Define versions and download locations
+ARG ARCH_TYPE=aarch64
+ARG CONDA_VER=4.8.3-5
+ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${CONDA_VER}/Miniforge3-${CONDA_VER}-Linux-${ARCH_TYPE}.sh
+
+# Set environment
+ENV PATH=/opt/conda/bin:${PATH}
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set CUDA_VERSION as in some 'nvidia/cuda' images this is not set
+## A lot of scripts and conda recipes depend on this env var
+ENV CUDA_VERSION=${FULL_CUDA_VER}
+
+# Enables "source activate conda"
+SHELL ["/bin/bash", "-c"]
+
+# Update and add pkgs for Ubuntu, also generate locales for 'en_US.UTF-8'
+RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
+      apt-get update \
+      && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        bzip2 \
+        ca-certificates \
+        curl \
+        git \
+        locales \
+        patch \
+        tzdata \
+        unzip \
+        wget \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/* \
+      && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+      && locale-gen ; \
+    else \
+      echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'ubuntu16.04' or 'ubuntu18.04'\n\n"; \
+    fi
+
+# Disable CUDA repo using the appropriate manager
+#   Also add langpack for locale in CentOS 8
+RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
+      yum-config-manager --disable cuda ; \
+    elif [ "${LINUX_VER}" == "centos8" ] ; then \
+      dnf install -y \
+        'dnf-command(config-manager)' \
+        glibc-langpack-en \
+      && dnf config-manager --set-disabled cuda ; \
+    fi
+
+# Update and add pkgs for CentOS
+RUN if [ "${LINUX_VER:0:6}" == "centos" ] ; then \
+      yum -y update \
+      && yum remove -y bind-license \
+      && yum -y install \
+        autoconf \
+        automake \
+        bzip2 \
+        ca-certificates \
+        curl \
+        git \
+        make \
+        patch \
+        unzip \
+        wget \
+        which \
+      && yum clean all ; \
+    else \
+      echo -e "\n\n>>>> SKIPPING: LINUX_VER is not 'centos7' or 'centos8'\n\n"; \
+    fi
+
+# Install miniforge and configure
+RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
+    && /bin/bash /miniforge.sh -b -p /opt/conda \
+    && rm -f /miniforge.sh \
+    && /opt/conda/bin/conda clean -tipsy \
+    && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
+    && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
+    && echo "conda activate base" >> ~/.bashrc \
+    && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/skel/.bashrc \
+    && echo "auto_update_conda: False" >> /opt/conda/.condarc \
+    && echo "ssl_verify: False" >> /opt/conda/.condarc \
+    && ln -s /opt/conda /conda
+
+# Install tini for init
+RUN conda install -k -y tini
+
+RUN chmod -R ugo+w /opt/conda
+
+# FIXME: /usr/bin/tini not found
+ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+CMD [ "/bin/bash" ]

--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -1,0 +1,128 @@
+ARG FROM_IMAGE=gpuci-miniforge-l4t
+ARG CUDA_VER=10.2
+ARG LINUX_VER=ubuntu18.04
+ARG IMAGE_TYPE=devel
+FROM ${FROM_IMAGE}:${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}
+
+# Required arguments
+ARG RAPIDS_CHANNEL=rapidsai-nightly
+ARG RAPIDS_VER=0.15
+ARG PYTHON_VER=3.7
+
+# Optional arguments
+ARG BUILD_STACK_VER=9.3.0
+
+# Capture argument used for FROM
+ARG CUDA_VER
+
+# Update environment for gcc/g++ builds
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++
+ENV CUDAHOSTCXX=/usr/bin/g++
+ENV CUDA_HOME=/usr/local/cuda
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
+
+# Enables "source activate conda"
+SHELL ["/bin/bash", "-c"]
+
+# Add a condarc for channels and override settings
+RUN if [ "${RAPIDS_CHANNEL}" == "rapidsai" ] ; then \
+      echo -e "\
+auto_update_conda: False \n\
+ssl_verify: False \n\
+channels: \n\
+  - gpuci \n\
+  - rapidsai \n\
+  - nvidia \n\
+  - pytorch \n\
+  - conda-forge \n\
+  - defaults \n" > /opt/conda/.condarc \
+      && cat /opt/conda/.condarc ; \
+    else \
+      echo -e "\
+auto_update_conda: False \n\
+ssl_verify: False \n\
+channels: \n\
+  - gpuci \n\
+  - rapidsai-nightly \n\
+  - rapidsai \n\
+  - nvidia \n\
+  - pytorch \n\
+  - conda-forge \n\
+  - defaults \n" > /opt/conda/.condarc \
+      && cat /opt/conda/.condarc ; \
+    fi
+
+# Install gcc7 - 7.5.0 to bring build stack in line with conda-forge
+RUN apt-get update \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && apt-get update \
+    && apt-get install -y gcc-7 g++-7 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7 \
+    && update-alternatives --set gcc /usr/bin/gcc-7 \
+    && update-alternatives --set g++ /usr/bin/g++-7 \
+    && gcc --version \
+    && g++ --version
+
+# Update and add pkgs for gpuci builds
+RUN apt-get update -y --fix-missing \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
+    && apt-get install -y \
+      chrpath \
+      libnuma1 \
+      libnuma-dev \
+      screen \
+      tzdata \
+      vim \
+      zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install latest jq
+ARG JQPATH=/usr/local/bin/jq
+RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O ${JQPATH} \
+    && chmod +x $JQPATH
+
+# Install latest awscli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" \
+    && unzip -q awscliv2.zip \
+    && ./aws/install \
+    && rm -rf ./aws ./awscliv2.zip
+
+# Add core tools to base env
+RUN conda install -y gpuci-tools \
+    || conda install -y gpuci-tools
+
+RUN gpuci_conda_retry install -y \
+      anaconda-client \
+      codecov
+# FIXME: Install rapids-scout-local
+#      rapids-scout-local
+
+# Create `rapids` conda env and make default
+RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+      -c nvidia \
+      -c conda-forge \
+      -c defaults \
+      -c gpuci \
+      git \
+      gpuci-tools \
+      libgcc-ng=${BUILD_STACK_VER} \
+      libstdcxx-ng=${BUILD_STACK_VER} \
+      python=${PYTHON_VER} \
+      'python_abi=*=*cp*' \
+      "setuptools<50" \
+    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+
+# Create symlink for old scripts expecting `gdf` conda env
+RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
+
+# Clean up pkgs to reduce image size and chmod for all users
+RUN chmod -R ugo+w /opt/conda \
+    && conda clean -tipy \
+    && chmod -R ugo+w /opt/conda
+
+ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
Based off of the [gpuciio/cuda-l4t](https://github.com/gpuciio/cuda-l4t) images add support for the following:

- [x] miniforge-cuda-l4t images - for base conda install
- [x] rapidsai-l4t images - for build/testing