### PR TITLE
FIX Enable CUDA 11.2 CentOS 7 builds

### DIFF
--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -59,8 +59,6 @@ exclude:
     LINUX_VER: centos8
   - CUDA_VER: 10.0.130
     LINUX_VER: centos8
-  - CUDA_VER: 11.2.2
-    LINUX_VER: centos7
 # Uncomment below and `- gpuci/cuda` above to build using gpuCI CUDA images
 # NOTE: gpuci/cuda:11.0* is 11.0.194 and would need CUDA_VER to change on revert
 #  - CUDA_VER: 9.0.176

--- a/ci/axis/miniforge-cuda.yml
+++ b/ci/axis/miniforge-cuda.yml
@@ -61,5 +61,3 @@ exclude:
     LINUX_VER: centos8
   - CUDA_VER: 10.0.130
     LINUX_VER: centos8
-  - CUDA_VER: 11.2.2
-    LINUX_VER: centos7

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -75,5 +75,3 @@ exclude:
     CUDA_VER: 10.2
   - LINUX_VER: centos8
     CUDA_VER: 10.2
-  - LINUX_VER: centos7
-    CUDA_VER: 11.2


### PR DESCRIPTION
Upstream nvidia/cuda now has CUDA 11.2 CentOS 7 builds, so we can remove the exclusions to build them now