### PR TITLE
Don't install weak dependencies on centos

### DIFF
--- a/builds-gcc7/Dockerfile.centos7
+++ b/builds-gcc7/Dockerfile.centos7
@@ -15,7 +15,7 @@ ARG NUM_BUILD_CPUS=16
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH_POSTBUILD:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs
 
 RUN yum upgrade -y \
-    && yum install -y \
+    && yum install -y --setopt=install_weak_deps=False \
       bzip2 \
       curl \
       git \

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -67,7 +67,7 @@ RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
 RUN if [ "${LINUX_VER:0:6}" == "centos" ] ; then \
       yum -y update \
       && yum remove -y bind-license \
-      && yum -y install \
+      && yum -y install --setopt=install_weak_deps=False \
         autoconf \
         automake \
         bzip2 \

--- a/miniforge-cuda-l4t/Dockerfile
+++ b/miniforge-cuda-l4t/Dockerfile
@@ -62,7 +62,7 @@ RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
 RUN if [ "${LINUX_VER:0:6}" == "centos" ] ; then \
       yum -y update \
       && yum remove -y bind-license \
-      && yum -y install \
+      && yum -y install --setopt=install_weak_deps=False \
         autoconf \
         automake \
         bzip2 \

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -63,7 +63,7 @@ RUN if [ "${LINUX_VER}" == "centos7" ] ; then \
 RUN if [ "${LINUX_VER:0:6}" == "centos" ] ; then \
       yum -y update \
       && yum remove -y bind-license \
-      && yum -y install \
+      && yum -y install --setopt=install_weak_deps=False \
         autoconf \
         automake \
         bzip2 \

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -57,7 +57,7 @@ channels: \n\
 
 # Update and add pkgs for gpuci builds
 RUN yum install -y epel-release \
-    && yum install -y \
+    && yum install -y --setopt=install_weak_deps=False \
       chrpath \
       clang \
       numactl-devel \


### PR DESCRIPTION
On CentOS 8, `perl-IO-Socket-SSL` is a weak dependency of `git`. `perl-IO-Socket-SSL` triggers flags on security scans due to including private RSA keys.

This PR prevents installing those weak dependencies.