### PR TITLE
CalVer - convert 0.20 to 21.06

### DIFF
--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -12,7 +12,7 @@ DOCKER_FILE:
   - centos.Dockerfile
 
 RAPIDS_VER:
-  - '0.20'
+  - '21.06'
 
 CUDA_VER:
   - 11.2

--- a/ci/axis/rapidsai-l4t.yml
+++ b/ci/axis/rapidsai-l4t.yml
@@ -11,7 +11,7 @@ DOCKER_FILE:
   - Dockerfile
 
 RAPIDS_VER:
-  - 0.19
+  - '21.06'
 
 RAPIDS_CHANNEL:
   - rapidsai-nightly

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -13,7 +13,7 @@ DOCKER_FILE:
   - devel-centos.Dockerfile
 
 RAPIDS_VER:
-  - '0.20'
+  - '21.06'
 
 RAPIDS_CHANNEL:
   - rapidsai-nightly


### PR DESCRIPTION
Do not merge until Friday May 14!

Just updates the axis files for the new version.