### PR TITLE
Allow arm builds to fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,18 +93,20 @@ pipeline {
         }
         stage('gpuCI/build/miniforge-cuda-driver-arm64') {
           steps {
-            retry(1) {
-              build(
-                job:
-                'gpuci/gpuci-build-environment-jobs/miniforge-cuda-driver-arm64',
-                wait: true,
-                propagate: true,
-                parameters: [
-                  string(name: 'GIT_URL', value: env.GIT_URL),
-                  string(name: 'PR_ID', value: (env.CHANGE_ID == null) ? 'BRANCH' : env.CHANGE_ID),
-                  string(name: 'COMMIT_HASH', value: (env.CHANGE_ID == null) ? env.GIT_BRANCH : 'origin/pr/'+env.CHANGE_ID+'/merge')
-                ]
-              )
+            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+              retry(1) {
+                build(
+                  job:
+                  'gpuci/gpuci-build-environment-jobs/miniforge-cuda-driver-arm64',
+                  wait: true,
+                  propagate: true,
+                  parameters: [
+                    string(name: 'GIT_URL', value: env.GIT_URL),
+                    string(name: 'PR_ID', value: (env.CHANGE_ID == null) ? 'BRANCH' : env.CHANGE_ID),
+                    string(name: 'COMMIT_HASH', value: (env.CHANGE_ID == null) ? env.GIT_BRANCH : 'origin/pr/'+env.CHANGE_ID+'/merge')
+                  ]
+                )
+              }
             }
           }
         }


### PR DESCRIPTION
This PR wraps the `gpuci/gpuci-build-environment-jobs/miniforge-cuda-driver-arm64` stage in a `catchError` block, which should prevent any failures in that stage from preventing the rest of the pipeline from completing. This should be fine since `arm` support is still a work-in-progress.