### PR TITLE
Add pin for cuda drivers

### DIFF
--- a/miniforge-cuda-driver/ubuntu.Dockerfile
+++ b/miniforge-cuda-driver/ubuntu.Dockerfile
@@ -7,7 +7,8 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}
 #    and installs build deps for conda builds
 
 # Required arguments
-ARG DRIVER_VER="440"
+ARG DRIVER_VER="450"
+ARG LINUX_VER
 
 # Add core tools to base env
 RUN source activate base \
@@ -29,7 +30,8 @@ RUN if [ $(arch) = "x86_64" ]; then \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* ; \
   elif [ $(arch) = "aarch64" ]; then \
-    apt-get update -q \
+    wget "http://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER//./}/sbsa/cuda-${LINUX_VER//./}.pin" -O /etc/apt/preferences.d/cuda-repository-pin-600 \
+    && apt-get update -q \
     && apt-get -qq install apt-utils -y --no-install-recommends \
       nvidia-driver-${DRIVER_VER} \
       cuda-drivers-${DRIVER_VER} \


### PR DESCRIPTION
Need to pin the CUDA drivers to use NVIDIA's repo instead of Canonical's.

This fixes installing the driver on arm64 sbsa images