### PR TITLE
Update `conda` environment name for CI

### DIFF
--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -113,9 +113,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
-# Create symlink for old scripts expecting `gdf` conda env
-RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
-
 # Clean up pkgs to reduce image size and chmod for all users
 RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -61,9 +61,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
-# Create symlink for old scripts expecting `gdf` conda env
-RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
-
 # For `runtime` images install notebook env meta-pkg
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -97,9 +97,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
-# Create symlink for old scripts expecting `gdf` conda env
-RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
-
 # Install build/doc/notebook env meta-pkgs
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -111,9 +111,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
-# Create symlink for old scripts expecting `gdf` conda env
-RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
-
 # Install build/doc/notebook env meta-pkgs
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &

--- a/templates/ci/checks/style.sh
+++ b/templates/ci/checks/style.sh
@@ -14,7 +14,8 @@ LC_ALL=C.UTF-8
 LANG=C.UTF-8
 
 # Activate common conda env
-source activate gdf
+. /opt/conda/etc/profile.d/conda.sh
+conda activate rapids
 
 # Run isort and get results/return code
 ISORT=`isort --recursive --check-only python`

--- a/templates/ci/cpu/cpubuild.sh
+++ b/templates/ci/cpu/cpubuild.sh
@@ -43,7 +43,8 @@ logger "Get env..."
 env
 
 logger "Activate conda env..."
-source activate gdf
+. /opt/conda/etc/profile.d/conda.sh
+conda activate rapids
 
 logger "Check versions..."
 python --version

--- a/templates/ci/gpu/gpubuild.sh
+++ b/templates/ci/gpu/gpubuild.sh
@@ -44,7 +44,8 @@ logger "Check GPU usage..."
 nvidia-smi
 
 logger "Activate conda env..."
-source activate gdf
+. /opt/conda/etc/profile.d/conda.sh
+conda activate rapids
 ##*
 ## EDIT: Install all build, runtime, and test dependencies
 conda install |<build_dep>| |<runtime_dep>| |<test_dep>|


### PR DESCRIPTION
The `gdf` conda environment has been replaced with the `rapids` environment. A symlink was put in place for `gdf` to continue to work, but the symlink will be removed in the near future. This PR updates all scripts to use the `rapids` environment name.
