### PR TITLE
[REVIEW] ENH Install and use mamba for package management

### DIFF
--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -81,10 +81,11 @@ RUN conda install -y gpuci-tools \
 RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
+      mamba \
       rapids-scout-local
 
 # Create `rapids` conda env and make default
-RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
@@ -102,11 +103,11 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \
-    && gpuci_conda_retry remove -y -n rapids --force-remove \
+    && gpuci_mamba_retry remove -y -n rapids --force-remove \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -24,6 +24,9 @@ ENV CUDA_HOME=/usr/local/cuda
 ENV LD_LIBRARY_PATH=${GCC9_DIR}/lib64:$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
 ENV PATH=${GCC9_DIR}/bin:$PATH
 
+# Set variable for mambarc
+ENV CONDARC=/opt/conda/.condarc
+
 # Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]
 
@@ -38,7 +41,7 @@ channels: \n\
   - nvidia \n\
   - pytorch \n\
   - conda-forge \n" > /opt/conda/.condarc \
-      && cat /opt/conda/.condarc ; \
+      && cat ${CONDARC} ; \
     else \
       echo -e "\
 auto_update_conda: False \n\
@@ -50,7 +53,7 @@ channels: \n\
   - nvidia \n\
   - pytorch \n\
   - conda-forge \n" > /opt/conda/.condarc \
-      && cat /opt/conda/.condarc ; \
+      && cat ${CONDARC} ; \
     fi
 
 # Update and add pkgs for gpuci builds
@@ -103,11 +106,11 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
+RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \
-    && gpuci_mamba_retry remove -y -n rapids --force-remove \
+    && gpuci_conda_retry remove -y -n rapids --force-remove \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -81,11 +81,10 @@ RUN conda install -y gpuci-tools \
 RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
-      mamba \
       rapids-scout-local
 
 # Create `rapids` conda env and make default
-RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
@@ -94,6 +93,7 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       gpuci-tools \
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
+      mamba \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools<50" \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -122,11 +122,11 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
 RUN source activate rapids \
-    && gpuci_mamba_retry install -y --freeze-installed \
+    && gpuci_conda_retry install -y --freeze-installed \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \
-    && gpuci_mamba_retry remove -y --force-remove \
+    && gpuci_conda_retry remove -y --force-remove \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -95,10 +95,11 @@ RUN conda install -y gpuci-tools \
 RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
+      mamba \
       rapids-scout-local
 
 # Create `rapids` conda env and make default
-RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
@@ -116,11 +117,11 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \
-    && gpuci_conda_retry remove -y -n rapids --force-remove \
+    && gpuci_mamba_retry remove -y -n rapids --force-remove \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -21,6 +21,9 @@ ENV CUDAHOSTCXX=/usr/bin/g++
 ENV CUDA_HOME=/usr/local/cuda
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
 
+# Set variable for mambarc
+ENV CONDARC=/opt/conda/.condarc
+
 # Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]
 
@@ -35,7 +38,7 @@ channels: \n\
   - nvidia \n\
   - pytorch \n\
   - conda-forge \n" > /opt/conda/.condarc \
-      && cat /opt/conda/.condarc ; \
+      && cat ${CONDARC} ; \
     else \
       echo -e "\
 auto_update_conda: False \n\
@@ -47,7 +50,7 @@ channels: \n\
   - nvidia \n\
   - pytorch \n\
   - conda-forge \n" > /opt/conda/.condarc \
-      && cat /opt/conda/.condarc ; \
+      && cat ${CONDARC} ; \
     fi
 
 # Install gcc9
@@ -118,11 +121,12 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN gpuci_mamba_retry install -y -n rapids --freeze-installed \
+RUN source activate rapids \
+    && gpuci_mamba_retry install -y --freeze-installed \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \
-    && gpuci_mamba_retry remove -y -n rapids --force-remove \
+    && gpuci_mamba_retry remove -y --force-remove \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -99,7 +99,7 @@ RUN gpuci_conda_retry install -y \
       rapids-scout-local
 
 # Create `rapids` conda env and make default
-RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
@@ -108,6 +108,7 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       gpuci-tools \
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
+      mamba \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools<50" \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -120,12 +120,11 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN source activate rapids \
-    && gpuci_conda_retry install -y --freeze-installed \
+RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \
-    && gpuci_conda_retry remove -y --force-remove \
+    && gpuci_conda_retry remove -y -n rapids --force-remove \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -98,7 +98,6 @@ RUN conda install -y gpuci-tools \
 RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
-      mamba \
       rapids-scout-local
 
 # Create `rapids` conda env and make default


### PR DESCRIPTION
This PR installs mamba into the rapids environment of the gpuCI image and standardizes the use of it as the package manager after installation.