### PR TITLE
auto-retry branch job on failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,9 @@ pipeline {
       label 'runner'
     }
   }
+  options {
+    retry(2)
+  }
   stages {
     stage('gpuCI/parallel/miniconda-miniforge') {
       parallel {


### PR DESCRIPTION
# Summary
This PR configures the gpuci-build-environment job to automatically retry without requiring manual intervention

# Testing Evidence
https://gpuci.gpuopenanalytics.com/job/gpuci/job/gpuci-build-environment/view/change-requests/job/PR-195/2/

# Issue
https://github.com/rapidsai/ops/issues/1463