### PR TITLE
Update for 21.10

### DIFF
--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -12,6 +12,7 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '21.08'
+  - '21.10'
 
 CUDA_VER:
   - 11.2

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -14,6 +14,7 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '21.08'
+  - '21.10'
 
 RAPIDS_CHANNEL:
   - rapidsai-nightly


### PR DESCRIPTION
Just adds `21.10` to the axes. Probably will fail initially while we wait for the build environment packages to be built in integration.