### PR TITLE
[REVIEW] FIX Add retry to docker build

### DIFF
--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -119,7 +119,9 @@ echo "docker build --pull -t ${BUILD_IMAGE}:${BUILD_TAG} ${BUILD_ARGS} -f ${IMAG
 
 # Build image
 gpuci_logger "Starting build..."
-docker build --pull -t ${BUILD_IMAGE}:${BUILD_TAG} ${BUILD_ARGS} -f ${IMAGE_NAME}/${DOCKER_FILE} ${IMAGE_NAME}/
+GPUCI_RETRY_MAX=1
+GPUCI_RETRY_SLEEP=120
+gpuci_retry docker build --pull -t ${BUILD_IMAGE}:${BUILD_TAG} ${BUILD_ARGS} -f ${IMAGE_NAME}/${DOCKER_FILE} ${IMAGE_NAME}/
 
 # List image info
 gpuci_logger "Displaying image info..."


### PR DESCRIPTION
Several pipelines for the build environment are failing transiently in at least one combination and causing images not to be released due to a single failure across 20+ combinations. This retry command should get us around any transient errors that happen and hopefully solve the problem.

https://gpuci.gpuopenanalytics.com/job/gpuci/job/gpuci-build-environment-nightly/