### PR TITLE
[REVIEW] ENH Install Git LFS

### DIFF
--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -102,6 +102,10 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
+# Install Git LFS
+curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | sudo bash
+sudo yum install git-lfs
+
 # Install build/doc/notebook env meta-pkgs
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -93,6 +93,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       git \
+      git-lfs \
       gpuci-tools \
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
@@ -101,10 +102,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       'python_abi=*=*cp*' \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
-
-# Install Git LFS
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | sudo bash \
-    && yum install git-lfs
 
 # Install build/doc/notebook env meta-pkgs
 #

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -104,7 +104,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
 
 # Install Git LFS
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | sudo bash \
-    && sudo yum install git-lfs
+    && yum install git-lfs
 
 # Install build/doc/notebook env meta-pkgs
 #

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -103,8 +103,8 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
 # Install Git LFS
-curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | sudo bash
-sudo yum install git-lfs
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | sudo bash \
+    && sudo yum install git-lfs
 
 # Install build/doc/notebook env meta-pkgs
 #

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -107,6 +107,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       git \
+      git-lfs \
       gpuci-tools \
       libgcc-ng=${BUILD_STACK_VER} \
       libstdcxx-ng=${BUILD_STACK_VER} \
@@ -115,10 +116,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       'python_abi=*=*cp*' \
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
-
-# Install Git LFS
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash \
-    && apt-get install git-lfs
 
 # Install build/doc/notebook env meta-pkgs
 #

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -116,6 +116,10 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       "setuptools<50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
+# Install Git LFS
+curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+sudo apt-get install git-lfs
+
 # Install build/doc/notebook env meta-pkgs
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -118,7 +118,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
 
 # Install Git LFS
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash \
-    && sudo apt-get install git-lfs
+    && apt-get install git-lfs
 
 # Install build/doc/notebook env meta-pkgs
 #

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -117,8 +117,8 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
 # Install Git LFS
-curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
-sudo apt-get install git-lfs
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash \
+    && sudo apt-get install git-lfs
 
 # Install build/doc/notebook env meta-pkgs
 #


### PR DESCRIPTION
Adds Git LFS to our gpuCI environment. This is needed for repositories that utilize Git LFS since the `size-check` job in gpuCI uses checkouts. Since it currently does not exist, a `size-check` job on a repository with Git LFS can fail with the following:

```
12:47:11 Branch branch-0.2-EA set up to track remote branch branch-0.2-EA from origin.
12:47:11 \nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-checkout.\n
12:47:11 Build step 'Execute shell' marked build as failure
```