### PR TITLE
Update `rapids-driver` to publish `ubuntu20.04` images

### DIFF
--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -15,7 +15,7 @@ DOCKER_FILE:
 #   so it can be used in all images within gpuCI; to make parsing easier we add
 #   it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
-  - 11.4.0
+  - 11.4.1
   - 11.3.1
   - 11.2.2
   - 11.1.1

--- a/ci/axis/miniforge-cuda-arm64.yml
+++ b/ci/axis/miniforge-cuda-arm64.yml
@@ -17,7 +17,7 @@ ARCH_TYPE:
 # so it can be used in all images within gpuCI; to make parsing easier we add
 # it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
-  - 11.4.0
+  - 11.4.1
   - 11.3.1
   - 11.2.2
   - 11.1.1

--- a/ci/axis/miniforge-cuda.yml
+++ b/ci/axis/miniforge-cuda.yml
@@ -17,7 +17,7 @@ ARCH_TYPE:
 # so it can be used in all images within gpuCI; to make parsing easier we add
 # it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
-  - 11.4.0
+  - 11.4.1
   - 11.3.1
   - 11.2.2
   - 11.1.1

--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -24,6 +24,7 @@ IMAGE_TYPE:
 
 LINUX_VER:
   - centos7
+  - ubuntu20.04
 
 PYTHON_VER:
   - 3.7

--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -12,7 +12,6 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '21.08'
-  - '21.10'
 
 CUDA_VER:
   - 11.4

--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -8,6 +8,7 @@ IMAGE_NAME:
   - rapidsai-driver
 
 DOCKER_FILE:
+  - Dockerfile
   - centos.Dockerfile
 
 RAPIDS_VER:
@@ -47,3 +48,7 @@ exclude:
     DRIVER_VER: 450
   - CUDA_VER: 11.4
     DRIVER_VER: 460
+  - DOCKER_FILE: Dockerfile
+    LINUX_VER: centos7
+  - DOCKER_FILE: centos.Dockerfile
+    LINUX_VER: ubuntu20.04

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -14,7 +14,6 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '21.08'
-  - '21.10'
 
 RAPIDS_CHANNEL:
   - rapidsai-nightly

--- a/rapidsai-driver/Dockerfile
+++ b/rapidsai-driver/Dockerfile
@@ -13,7 +13,6 @@ ARG DRIVER_VER="440"
 # Update and add pkgs
 RUN apt-get update -q \
     && apt-get -qq install apt-utils -y --no-install-recommends \
-      nvidia-${DRIVER_VER}-dev \
-      libcuda1-${DRIVER_VER} \
+      cuda-drivers-${DRIVER_VER} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR updates `branch-21.08` to publish `ubuntu20.04` variants of the `rapidsai-driver` image.

Additionally, it backports https://github.com/rapidsai/gpuci-build-environment/pull/203/commits/508e7f74d6cdb281cc78394b6edc4430fa53f816 to `branch-21.08` and removes `21.10` from the axis files so that `21.10` packages don't get built/published from `branch-21.08`.