### PR TITLE
Install openmpi in rapidsai devel images

### DIFF
--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -22,7 +22,7 @@ ENV CXX=${GCC9_DIR}/bin/g++
 ENV CUDAHOSTCXX=${GCC9_DIR}/bin/g++
 ENV CUDA_HOME=/usr/local/cuda
 ENV LD_LIBRARY_PATH=${GCC9_DIR}/lib64:$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
-ENV PATH=${GCC9_DIR}/bin:$PATH
+ENV PATH=${GCC9_DIR}/bin:/usr/lib64/openmpi/bin:$PATH
 
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc
@@ -64,6 +64,7 @@ RUN yum install -y epel-release \
       file \
       numactl-devel \
       numactl-libs \
+      openmpi-devel \
       screen \
       vim \
     && yum clean all

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -74,6 +74,8 @@ RUN apt-get update -y --fix-missing \
       file \
       libnuma1 \
       libnuma-dev \
+      libopenmpi-dev \
+      openmpi-bin \
       screen \
       tzdata \
       vim \

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -74,6 +74,8 @@ RUN apt-get update -y --fix-missing \
       file \
       libnuma1 \
       libnuma-dev \
+      libopenmpi-dev \
+      openmpi-bin \
       screen \
       tzdata \
       vim \


### PR DESCRIPTION
Just install `openmpi` packages in `gpuci/rapidsai` `devel` images. 

This is to support rapidsai/cugraph#1805