### PR TITLE
Move `libnuma` to `miniconda-cuda` image

### DIFF
--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -39,6 +39,8 @@ RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
         curl \
         git \
         locales \
+        libnuma1 \
+        libnuma-dev \
         patch \
         tzdata \
         unzip \
@@ -75,6 +77,8 @@ RUN if [ "${LINUX_VER:0:6}" == "centos" ] ; then \
         curl \
         git \
         make \
+        numactl-devel \
+        numactl-libs \
         patch \
         unzip \
         wget \

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -62,8 +62,6 @@ RUN yum install -y epel-release \
       chrpath \
       clang \
       file \
-      numactl-devel \
-      numactl-libs \
       openmpi-devel \
       screen \
       vim \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -72,8 +72,6 @@ RUN apt-get update -y --fix-missing \
     && apt-get install -y \
       chrpath \
       file \
-      libnuma1 \
-      libnuma-dev \
       libopenmpi-dev \
       openmpi-bin \
       screen \


### PR DESCRIPTION
This PR moves the `libnuma` installation from the `rapidsai` images to the `miniconda-cuda` image. This is to prevent `ImportError: libnuma.so.1: cannot open shared object file: No such file or directory` errors in the `integration` repository (like the one in [this PR](https://github.com/rapidsai/integration/pull/347)).