### PR TITLE
Install tini using conda

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ RUN source activate base \
 ## Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]
 
-ENTRYPOINT [ "/usr/bin/tini", "--" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
 CMD [ "/bin/bash" ]
 ```
 

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -10,9 +10,7 @@ ARG LINUX_VER
 
 # Define versions and download locations
 ARG CONDA_VER=4.10.3
-ARG TINI_VER=v0.18.0
 ARG MINICONDA_URL=http://repo.anaconda.com/miniconda/Miniconda3-py38_${CONDA_VER}-Linux-x86_64.sh
-ARG TINI_URL=https://github.com/krallin/tini/releases/download/${TINI_VER}/tini
 
 # Set environment
 ENV CONDA_DIR=/opt/conda
@@ -106,8 +104,8 @@ RUN chmod -R ugo+w /opt/conda \
     && chmod -R ugo+w /opt/conda
 
 # Install tini for init
-RUN wget --quiet ${TINI_URL} -O /usr/bin/tini \
-    && chmod +x /usr/bin/tini
+RUN conda install -k -y tini \
+    || conda install -k -y tini
 
-ENTRYPOINT [ "/usr/bin/tini", "--" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/miniforge-cuda-l4t/Dockerfile
+++ b/miniforge-cuda-l4t/Dockerfile
@@ -98,6 +98,5 @@ RUN conda install -k -y tini \
 
 RUN chmod -R ugo+w /opt/conda
 
-# FIXME: /usr/bin/tini not found
 ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -79,5 +79,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/usr/bin/tini", "--" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -128,5 +128,5 @@ RUN chmod -R ugo+w /opt/conda \
 # Add GDS header cufile.h to image
 COPY cufile.h /usr/local/cuda/targets/x86_64-linux/lib/cufile.h
 
-ENTRYPOINT [ "/usr/bin/tini", "--" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -120,5 +120,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/usr/bin/tini", "--" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -138,5 +138,5 @@ RUN chmod -R ugo+w /opt/conda \
 # Add GDS header cufile.h to image
 COPY cufile.h /usr/local/cuda/targets/x86_64-linux/lib/cufile.h
 
-ENTRYPOINT [ "/usr/bin/tini", "--" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
Unify how we install `tini` between `miniforge` and `miniconda` images so we can set `/opt/conda/bin/tini` as entrypoint for both