### PR TITLE
Update axes for `11.5`

### DIFF
--- a/ci/axis/miniconda-cuda-driver.yml
+++ b/ci/axis/miniconda-cuda-driver.yml
@@ -12,6 +12,7 @@ DOCKER_FILE:
   - centos7.Dockerfile
 
 CUDA_VER:
+  - 11.5
   - 11.4
   - 11.3
   - 11.2
@@ -31,6 +32,7 @@ DRIVER_VER:
   - 460
   - 465
   - 470
+  - 495
 
 exclude:
   - DOCKER_FILE: Dockerfile
@@ -46,6 +48,8 @@ exclude:
     DRIVER_VER: 465
   - CUDA_VER: 11.0
     DRIVER_VER: 470
+  - CUDA_VER: 11.0
+    DRIVER_VER: 495
 
   - CUDA_VER: 11.1
     DRIVER_VER: 450
@@ -55,6 +59,8 @@ exclude:
     DRIVER_VER: 465
   - CUDA_VER: 11.1
     DRIVER_VER: 470
+  - CUDA_VER: 11.1
+    DRIVER_VER: 495
 
   - CUDA_VER: 11.2
     DRIVER_VER: 450
@@ -64,6 +70,8 @@ exclude:
     DRIVER_VER: 465
   - CUDA_VER: 11.2
     DRIVER_VER: 470
+  - CUDA_VER: 11.2
+    DRIVER_VER: 495
 
   - CUDA_VER: 11.3
     DRIVER_VER: 450
@@ -73,6 +81,8 @@ exclude:
     DRIVER_VER: 460
   - CUDA_VER: 11.3
     DRIVER_VER: 470
+  - CUDA_VER: 11.3
+    DRIVER_VER: 495
 
   - CUDA_VER: 11.4
     DRIVER_VER: 450
@@ -82,3 +92,16 @@ exclude:
     DRIVER_VER: 460
   - CUDA_VER: 11.4
     DRIVER_VER: 465
+  - CUDA_VER: 11.4
+    DRIVER_VER: 495
+
+  - CUDA_VER: 11.5
+    DRIVER_VER: 450
+  - CUDA_VER: 11.5
+    DRIVER_VER: 455
+  - CUDA_VER: 11.5
+    DRIVER_VER: 460
+  - CUDA_VER: 11.5
+    DRIVER_VER: 465
+  - CUDA_VER: 11.5
+    DRIVER_VER: 470

--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -3,7 +3,7 @@ BUILD_IMAGE:
 
 FROM_IMAGE:
   - nvidia/cuda
-#  - gpuci/cuda
+  - gpuci/cuda
 
 IMAGE_NAME:
   - miniconda-cuda
@@ -15,6 +15,7 @@ DOCKER_FILE:
 #   so it can be used in all images within gpuCI; to make parsing easier we add
 #   it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
+  - 11.5.0
   - 11.4.1
   - 11.3.1
   - 11.2.2
@@ -62,15 +63,22 @@ exclude:
     LINUX_VER: centos8
 # Uncomment below and `- gpuci/cuda` above to build using gpuCI CUDA images
 # NOTE: gpuci/cuda:11.0* is 11.0.194 and would need CUDA_VER to change on revert
-#  - CUDA_VER: 9.0.176
-#    FROM_IMAGE: gpuci/cuda
-#  - CUDA_VER: 9.2.148
-#    FROM_IMAGE: gpuci/cuda
-#  - CUDA_VER: 10.0.130
-#    FROM_IMAGE: gpuci/cuda
-#  - CUDA_VER: 10.1.243
-#    FROM_IMAGE: gpuci/cuda
-#  - CUDA_VER: 10.2.89
-#    FROM_IMAGE: nvidia/cuda
-#  - CUDA_VER: 11.0.194
-#    FROM_IMAGE: nvidia/cuda
+  - CUDA_VER: 9.0.176
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 9.2.148
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 10.0.130
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 10.1.243
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 10.2.89
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.0.3
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.1.1
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.2.2
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.3.1
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.4.1

--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -82,3 +82,5 @@ exclude:
     CUDA_VER: 11.3.1
   - FROM_IMAGE: gpuci/cuda
     CUDA_VER: 11.4.1
+  - FROM_IMAGE: nvidia/cuda
+    CUDA_VER: 11.5.0

--- a/ci/axis/miniforge-cuda-arm64.yml
+++ b/ci/axis/miniforge-cuda-arm64.yml
@@ -50,3 +50,5 @@ exclude:
     CUDA_VER: 11.3.1
   - FROM_IMAGE: gpuci/cuda
     CUDA_VER: 11.4.1
+  - FROM_IMAGE: nvidia/cuda
+    CUDA_VER: 11.5.0

--- a/ci/axis/miniforge-cuda-arm64.yml
+++ b/ci/axis/miniforge-cuda-arm64.yml
@@ -3,6 +3,7 @@ BUILD_IMAGE:
 
 FROM_IMAGE:
   - nvidia/cuda
+  - gpuci/cuda
 
 IMAGE_NAME:
   - miniforge-cuda
@@ -17,6 +18,7 @@ ARCH_TYPE:
 # so it can be used in all images within gpuCI; to make parsing easier we add
 # it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
+  - 11.5.0
   - 11.4.1
   - 11.3.1
   - 11.2.2
@@ -38,3 +40,13 @@ exclude:
     CUDA_VER: 11.1.1
   - LINUX_VER: ubuntu20.04
     CUDA_VER: 11.0.3
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.0.3
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.1.1
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.2.2
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.3.1
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.4.1

--- a/ci/axis/miniforge-cuda-driver-arm64.yml
+++ b/ci/axis/miniforge-cuda-driver-arm64.yml
@@ -11,6 +11,7 @@ DOCKER_FILE:
   - ubuntu.Dockerfile
 
 CUDA_VER:
+  - 11.5
   - 11.4
   - 11.3
   - 11.2
@@ -29,6 +30,7 @@ DRIVER_VER:
   - 460
   - 465
   - 470
+  - 495
 
 exclude:
   - CUDA_VER: 11.0
@@ -39,6 +41,8 @@ exclude:
     DRIVER_VER: 465
   - CUDA_VER: 11.0
     DRIVER_VER: 470
+  - CUDA_VER: 11.0
+    DRIVER_VER: 495
 
   - CUDA_VER: 11.1
     DRIVER_VER: 450
@@ -48,6 +52,8 @@ exclude:
     DRIVER_VER: 465
   - CUDA_VER: 11.1
     DRIVER_VER: 470
+  - CUDA_VER: 11.1
+    DRIVER_VER: 495
 
   - CUDA_VER: 11.2
     DRIVER_VER: 450
@@ -57,6 +63,8 @@ exclude:
     DRIVER_VER: 465
   - CUDA_VER: 11.2
     DRIVER_VER: 470
+  - CUDA_VER: 11.2
+    DRIVER_VER: 495
 
   - CUDA_VER: 11.3
     DRIVER_VER: 450
@@ -66,6 +74,8 @@ exclude:
     DRIVER_VER: 460
   - CUDA_VER: 11.3
     DRIVER_VER: 470
+  - CUDA_VER: 11.3
+    DRIVER_VER: 495
 
   - CUDA_VER: 11.4
     DRIVER_VER: 450
@@ -75,3 +85,16 @@ exclude:
     DRIVER_VER: 460
   - CUDA_VER: 11.4
     DRIVER_VER: 465
+  - CUDA_VER: 11.4
+    DRIVER_VER: 495
+
+  - CUDA_VER: 11.5
+    DRIVER_VER: 450
+  - CUDA_VER: 11.5
+    DRIVER_VER: 455
+  - CUDA_VER: 11.5
+    DRIVER_VER: 460
+  - CUDA_VER: 11.5
+    DRIVER_VER: 465
+  - CUDA_VER: 11.5
+    DRIVER_VER: 470

--- a/ci/axis/miniforge-cuda.yml
+++ b/ci/axis/miniforge-cuda.yml
@@ -3,6 +3,7 @@ BUILD_IMAGE:
 
 FROM_IMAGE:
   - nvidia/cuda
+  - gpuci/cuda
 
 IMAGE_NAME:
   - miniforge-cuda
@@ -17,6 +18,7 @@ ARCH_TYPE:
 # so it can be used in all images within gpuCI; to make parsing easier we add
 # it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
+  - 11.5.0
   - 11.4.1
   - 11.3.1
   - 11.2.2
@@ -62,3 +64,24 @@ exclude:
     LINUX_VER: centos8
   - CUDA_VER: 10.0.130
     LINUX_VER: centos8
+# Uncomment below and `- gpuci/cuda` above to build using gpuCI CUDA images
+# NOTE: gpuci/cuda:11.0* is 11.0.194 and would need CUDA_VER to change on revert
+  - CUDA_VER: 9.0.176
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 9.2.148
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 10.0.130
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 10.1.243
+    FROM_IMAGE: gpuci/cuda
+  - CUDA_VER: 10.2.89
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.0.3
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.1.1
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.2.2
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.3.1
+  - FROM_IMAGE: gpuci/cuda
+    CUDA_VER: 11.4.1

--- a/ci/axis/miniforge-cuda.yml
+++ b/ci/axis/miniforge-cuda.yml
@@ -85,3 +85,5 @@ exclude:
     CUDA_VER: 11.3.1
   - FROM_IMAGE: gpuci/cuda
     CUDA_VER: 11.4.1
+  - FROM_IMAGE: nvidia/cuda
+    CUDA_VER: 11.5.0

--- a/ci/axis/rapidsai-arm64.yml
+++ b/ci/axis/rapidsai-arm64.yml
@@ -21,6 +21,7 @@ RAPIDS_CHANNEL:
 CUDA_VER:
   - 11.2
   - 11.4
+  - 11.5
 
 IMAGE_TYPE:
   - base

--- a/ci/axis/rapidsai-arm64.yml
+++ b/ci/axis/rapidsai-arm64.yml
@@ -13,7 +13,6 @@ DOCKER_FILE:
   - base-runtime.Dockerfile
 
 RAPIDS_VER:
-  - '21.10'
   - '21.12'
 
 RAPIDS_CHANNEL:

--- a/ci/axis/rapidsai-driver-arm64.yml
+++ b/ci/axis/rapidsai-driver-arm64.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - Dockerfile
 
 RAPIDS_VER:
-  - '21.10'
   - '21.12'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-driver-arm64.yml
+++ b/ci/axis/rapidsai-driver-arm64.yml
@@ -14,6 +14,7 @@ RAPIDS_VER:
   - '21.12'
 
 CUDA_VER:
+  - 11.5
   - 11.4
   - 11.2
 
@@ -30,9 +31,18 @@ PYTHON_VER:
 DRIVER_VER:
   - 460
   - 470
+  - 495
 
 exclude:
   - CUDA_VER: 11.2
     DRIVER_VER: 470
+  - CUDA_VER: 11.2
+    DRIVER_VER: 495
   - CUDA_VER: 11.4
     DRIVER_VER: 460
+  - CUDA_VER: 11.4
+    DRIVER_VER: 495
+  - CUDA_VER: 11.5
+    DRIVER_VER: 460
+  - CUDA_VER: 11.5
+    DRIVER_VER: 470

--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -14,6 +14,7 @@ RAPIDS_VER:
   - '21.12'
 
 CUDA_VER:
+  - 11.5
   - 11.4
   - 11.2
   - 11.0
@@ -32,17 +33,30 @@ DRIVER_VER:
   - 450
   - 460
   - 470
+  - 495
 
 exclude:
   - CUDA_VER: 11.0
     DRIVER_VER: 460
   - CUDA_VER: 11.0
     DRIVER_VER: 470
+  - CUDA_VER: 11.0
+    DRIVER_VER: 495
   - CUDA_VER: 11.2
     DRIVER_VER: 450
   - CUDA_VER: 11.2
     DRIVER_VER: 470
+  - CUDA_VER: 11.2
+    DRIVER_VER: 495
   - CUDA_VER: 11.4
     DRIVER_VER: 450
   - CUDA_VER: 11.4
     DRIVER_VER: 460
+  - CUDA_VER: 11.4
+    DRIVER_VER: 495
+  - CUDA_VER: 11.5
+    DRIVER_VER: 450
+  - CUDA_VER: 11.5
+    DRIVER_VER: 460
+  - CUDA_VER: 11.5
+    DRIVER_VER: 470

--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - centos.Dockerfile
 
 RAPIDS_VER:
-  - '21.10'
   - '21.12'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-l4t.yml
+++ b/ci/axis/rapidsai-l4t.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - Dockerfile
 
 RAPIDS_VER:
-  - '21.10'
   - '21.12'
 
 RAPIDS_CHANNEL:

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -13,7 +13,6 @@ DOCKER_FILE:
   - devel-centos.Dockerfile
 
 RAPIDS_VER:
-  - '21.10'
   - '21.12'
 
 RAPIDS_CHANNEL:

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -19,6 +19,7 @@ RAPIDS_CHANNEL:
   - rapidsai-nightly
 
 CUDA_VER:
+  - 11.5
   - 11.4
   - 11.2
   - 11.0


### PR DESCRIPTION
This PR adds CUDA `11.5` to our axes so that we can start building `11.5` packages.

The official `11.5` images from the [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda) DockerHub repository won't come out until later this week, so these changes configure that axes to use the [gpuci/cuda](https://hub.docker.com/r/gpuci/cuda/tags?page=1&name=11.5.0) DockerHub repository instead. That repository contains `11.5` images for `amd64` and `arm64` that I've built locally and pushed. This is because the CUDA `11.5` effort is high priority and we want to enable testing as soon as possible.

Once the official `nvidia/cuda` images come out, we should revert the `gpuci/cuda` changes in this PR.

Additionally, this PR removes `21.10` from the axes since that release is complete.