### PR TITLE
Install boa to gpuci/rapidsai images

### DIFF
--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -82,6 +82,7 @@ RUN conda install -y gpuci-tools \
     || conda install -y gpuci-tools
 RUN gpuci_conda_retry install -y \
       anaconda-client \
+      boa \
       codecov \
       mamba \
       rapids-scout-local

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -78,6 +78,7 @@ RUN conda install -y gpuci-tools \
     || conda install -y gpuci-tools
 RUN gpuci_conda_retry install -y \
       anaconda-client \
+      boa \
       codecov \
       jq \
       mamba \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -97,6 +97,7 @@ RUN conda install -y gpuci-tools \
     || conda install -y gpuci-tools
 RUN gpuci_conda_retry install -y \
       anaconda-client \
+      boa \
       codecov \
       mamba \
       rapids-scout-local

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -94,6 +94,7 @@ RUN conda install -y gpuci-tools \
     || conda install -y gpuci-tools
 RUN gpuci_conda_retry install -y \
       anaconda-client \
+      boa \
       codecov \
       jq \
       mamba \


### PR DESCRIPTION
Install `boa` to `gpuci/rapidsai` images to be able to use `mambabuild`