### PR TITLE
Remove `21.12` images from axis

### DIFF
--- a/ci/axis/rapidsai-arm64.yml
+++ b/ci/axis/rapidsai-arm64.yml
@@ -13,7 +13,6 @@ DOCKER_FILE:
   - base-runtime.Dockerfile
 
 RAPIDS_VER:
-  - '21.12'
   - '22.02'
 
 RAPIDS_CHANNEL:

--- a/ci/axis/rapidsai-driver-arm64.yml
+++ b/ci/axis/rapidsai-driver-arm64.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - Dockerfile
 
 RAPIDS_VER:
-  - '21.12'
   - '22.02'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - centos.Dockerfile
 
 RAPIDS_VER:
-  - '21.12'
   - '22.02'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-l4t.yml
+++ b/ci/axis/rapidsai-l4t.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - Dockerfile
 
 RAPIDS_VER:
-  - '21.12'
   - '22.02'
 
 RAPIDS_CHANNEL:

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -13,7 +13,6 @@ DOCKER_FILE:
   - devel-centos.Dockerfile
 
 RAPIDS_VER:
-  - '21.12'
   - '22.02'
 
 RAPIDS_CHANNEL:


### PR DESCRIPTION
Now that the `21.12` release is complete, we can remove the value from our axis files.