### PR TITLE
Update images to use `nvidia/cuda` instead of `gpuci/cuda`

### DIFF
--- a/ci/axis/miniconda-cuda.yml
+++ b/ci/axis/miniconda-cuda.yml
@@ -3,7 +3,7 @@ BUILD_IMAGE:
 
 FROM_IMAGE:
   - nvidia/cuda
-  - gpuci/cuda
+  # - gpuci/cuda
 
 IMAGE_NAME:
   - miniconda-cuda
@@ -15,7 +15,7 @@ DOCKER_FILE:
 #   so it can be used in all images within gpuCI; to make parsing easier we add
 #   it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
-  - 11.5.0
+  - 11.5.1
   - 11.4.1
   - 11.3.1
   - 11.2.2
@@ -63,24 +63,24 @@ exclude:
     LINUX_VER: centos8
 # Uncomment below and `- gpuci/cuda` above to build using gpuCI CUDA images
 # NOTE: gpuci/cuda:11.0* is 11.0.194 and would need CUDA_VER to change on revert
-  - CUDA_VER: 9.0.176
-    FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 9.2.148
-    FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 10.0.130
-    FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 10.1.243
-    FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 10.2.89
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.0.3
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.1.1
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.2.2
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.3.1
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.4.1
-  - FROM_IMAGE: nvidia/cuda
-    CUDA_VER: 11.5.0
+  # - CUDA_VER: 9.0.176
+  #   FROM_IMAGE: gpuci/cuda
+  # - CUDA_VER: 9.2.148
+  #   FROM_IMAGE: gpuci/cuda
+  # - CUDA_VER: 10.0.130
+  #   FROM_IMAGE: gpuci/cuda
+  # - CUDA_VER: 10.1.243
+  #   FROM_IMAGE: gpuci/cuda
+  # - CUDA_VER: 10.2.89
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.0.3
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.1.1
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.2.2
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.3.1
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.4.1
+  # - FROM_IMAGE: nvidia/cuda
+  #   CUDA_VER: 11.5.1

--- a/ci/axis/miniforge-cuda-arm64.yml
+++ b/ci/axis/miniforge-cuda-arm64.yml
@@ -3,7 +3,7 @@ BUILD_IMAGE:
 
 FROM_IMAGE:
   - nvidia/cuda
-  - gpuci/cuda
+  # - gpuci/cuda
 
 IMAGE_NAME:
   - miniforge-cuda
@@ -18,7 +18,7 @@ ARCH_TYPE:
 # so it can be used in all images within gpuCI; to make parsing easier we add
 # it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
-  - 11.5.0
+  - 11.5.1
   - 11.4.1
   - 11.3.1
   - 11.2.2
@@ -40,15 +40,15 @@ exclude:
     CUDA_VER: 11.1.1
   - LINUX_VER: ubuntu20.04
     CUDA_VER: 11.0.3
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.0.3
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.1.1
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.2.2
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.3.1
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.4.1
-  - FROM_IMAGE: nvidia/cuda
-    CUDA_VER: 11.5.0
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.0.3
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.1.1
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.2.2
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.3.1
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.4.1
+  # - FROM_IMAGE: nvidia/cuda
+  #   CUDA_VER: 11.5.1

--- a/ci/axis/miniforge-cuda.yml
+++ b/ci/axis/miniforge-cuda.yml
@@ -3,7 +3,7 @@ BUILD_IMAGE:
 
 FROM_IMAGE:
   - nvidia/cuda
-  - gpuci/cuda
+  # - gpuci/cuda
 
 IMAGE_NAME:
   - miniforge-cuda
@@ -14,11 +14,11 @@ DOCKER_FILE:
 ARCH_TYPE:
   - x86_64
 
-# CUDA_VERSION is not defined for CUDA 11 images - this defines it in this image
+# CUDA_VERSION is not defined for CUDA 11 images - this defines it in this image 
 # so it can be used in all images within gpuCI; to make parsing easier we add
 # it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
-  - 11.5.0
+  - 11.5.1
   - 11.4.1
   - 11.3.1
   - 11.2.2
@@ -66,24 +66,24 @@ exclude:
     LINUX_VER: centos8
 # Uncomment below and `- gpuci/cuda` above to build using gpuCI CUDA images
 # NOTE: gpuci/cuda:11.0* is 11.0.194 and would need CUDA_VER to change on revert
-  - CUDA_VER: 9.0.176
-    FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 9.2.148
-    FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 10.0.130
-    FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 10.1.243
-    FROM_IMAGE: gpuci/cuda
-  - CUDA_VER: 10.2.89
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.0.3
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.1.1
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.2.2
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.3.1
-  - FROM_IMAGE: gpuci/cuda
-    CUDA_VER: 11.4.1
-  - FROM_IMAGE: nvidia/cuda
-    CUDA_VER: 11.5.0
+  # - CUDA_VER: 9.0.176
+  #   FROM_IMAGE: gpuci/cuda
+  # - CUDA_VER: 9.2.148
+  #   FROM_IMAGE: gpuci/cuda
+  # - CUDA_VER: 10.0.130
+  #   FROM_IMAGE: gpuci/cuda
+  # - CUDA_VER: 10.1.243
+  #   FROM_IMAGE: gpuci/cuda
+  # - CUDA_VER: 10.2.89
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.0.3
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.1.1
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.2.2
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.3.1
+  # - FROM_IMAGE: gpuci/cuda
+  #   CUDA_VER: 11.4.1
+  # - FROM_IMAGE: nvidia/cuda
+  #   CUDA_VER: 11.5.1


### PR DESCRIPTION
This PR re-integrates the changes in #226 reverted by PR #227