### PR TITLE
removes cufile from Dockerfiles

### DIFF
--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -137,8 +137,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-# Add GDS header cufile.h to image
-COPY cufile.h /usr/local/cuda/targets/x86_64-linux/lib/cufile.h
-
 ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -135,8 +135,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-# Add GDS header cufile.h to image
-COPY cufile.h /usr/local/cuda/targets/x86_64-linux/lib/cufile.h
-
 ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
This PR removes the GDS header `cufile.h` from the `devel` images as we're building with CUDA `11.5`. `cufile.h` is included in CUDA Toolkit 11.4+.