### PR TITLE
added sccache to ci images

### DIFF
--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -105,8 +105,8 @@ RUN gpuci_conda_retry install -y \
 # Install sccache
 RUN wget https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
     && tar -xzf sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
-    && rm -r sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
-    && cp sccache-v0.2.15-x86_64-unknown-linux-musl/sccache /usr/local/bin \
+    && mv sccache-v0.2.15-x86_64-unknown-linux-musl/sccache /usr/local/bin \
+    && rm -rf sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz sccache-v0.2.15-x86_64-unknown-linux-musl/ \
     && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -102,6 +102,12 @@ RUN gpuci_conda_retry install -y \
       codecov \
       mamba \
       rapids-scout-local
+# Install sccache
+RUN wget https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
+    && tar -xzf sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
+    && rm -r sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
+    && cp sccache-v0.2.15-x86_64-unknown-linux-musl/sccache /usr/local/bin \
+    && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -7,6 +7,7 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-devel-${LINUX_VER}
 ARG RAPIDS_CHANNEL=rapidsai-nightly
 ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
+ARG SCCACHE_VERSION=0.2.15
 
 # Optional arguments
 ARG BUILD_STACK_VER=9.4.0
@@ -103,10 +104,10 @@ RUN gpuci_conda_retry install -y \
       mamba \
       rapids-scout-local
 # Install sccache
-RUN wget https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
-    && tar -xzf sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
-    && mv sccache-v0.2.15-x86_64-unknown-linux-musl/sccache /usr/local/bin \
-    && rm -rf sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz sccache-v0.2.15-x86_64-unknown-linux-musl/ \
+RUN wget https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz \
+    && tar -xzf sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz \
+    && mv sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin \
+    && rm -rf sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/ \
     && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -7,7 +7,6 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-devel-${LINUX_VER}
 ARG RAPIDS_CHANNEL=rapidsai-nightly
 ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
-ARG SCCACHE_VERSION=0.2.15
 
 # Optional arguments
 ARG BUILD_STACK_VER=9.4.0
@@ -103,18 +102,13 @@ RUN gpuci_conda_retry install -y \
       codecov \
       mamba \
       rapids-scout-local
-# Install sccache
-RUN wget https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-    && tar -xzf sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-    && mv sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin \
-    && rm -rf sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/ \
-    && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
+      sccache \
       cudatoolkit=${CUDA_VER} \
       git \
       git-lfs \

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -82,6 +82,12 @@ RUN gpuci_conda_retry install -y \
       jq \
       mamba \
       rapids-scout-local
+# Install sccache
+RUN wget https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
+    && tar -xzf sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
+    && rm -r sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
+    && cp sccache-v0.2.15-aarch64-unknown-linux-musl/sccache /usr/local/bin \
+    && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -7,7 +7,6 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-devel-${LINUX_VER}
 ARG RAPIDS_CHANNEL=rapidsai-nightly
 ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
-ARG SCCACHE_VERSION=0.2.15
 
 # Optional arguments
 ARG BUILD_STACK_VER=9.4.0
@@ -83,18 +82,13 @@ RUN gpuci_conda_retry install -y \
       jq \
       mamba \
       rapids-scout-local
-# Install sccache
-RUN wget https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz \
-    && tar -xzf sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz \
-    && mv sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl/sccache /usr/local/bin \
-    && rm -rf sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl/ \
-    && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
+      sccache \
       cudatoolkit=${CUDA_VER} \
       git \
       git-lfs \

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -85,8 +85,8 @@ RUN gpuci_conda_retry install -y \
 # Install sccache
 RUN wget https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
     && tar -xzf sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
-    && rm -r sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
-    && cp sccache-v0.2.15-aarch64-unknown-linux-musl/sccache /usr/local/bin \
+    && mv sccache-v0.2.15-aarch64-unknown-linux-musl/sccache /usr/local/bin \
+    && rm -rf sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz sccache-v0.2.15-aarch64-unknown-linux-musl/ \
     && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -7,6 +7,7 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-devel-${LINUX_VER}
 ARG RAPIDS_CHANNEL=rapidsai-nightly
 ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
+ARG SCCACHE_VERSION=0.2.15
 
 # Optional arguments
 ARG BUILD_STACK_VER=9.4.0
@@ -83,10 +84,10 @@ RUN gpuci_conda_retry install -y \
       mamba \
       rapids-scout-local
 # Install sccache
-RUN wget https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
-    && tar -xzf sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
-    && mv sccache-v0.2.15-aarch64-unknown-linux-musl/sccache /usr/local/bin \
-    && rm -rf sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz sccache-v0.2.15-aarch64-unknown-linux-musl/ \
+RUN wget https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz \
+    && tar -xzf sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz \
+    && mv sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl/sccache /usr/local/bin \
+    && rm -rf sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl/ \
     && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -103,8 +103,8 @@ RUN gpuci_conda_retry install -y \
 # Install sccache
 RUN wget https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
     && tar -xzf sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
-    && rm -r sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
-    && cp sccache-v0.2.15-x86_64-unknown-linux-musl/sccache /usr/local/bin \
+    && mv sccache-v0.2.15-x86_64-unknown-linux-musl/sccache /usr/local/bin \
+    && rm -rf sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz sccache-v0.2.15-x86_64-unknown-linux-musl/ \
     && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -100,6 +100,12 @@ RUN gpuci_conda_retry install -y \
       codecov \
       mamba \
       rapids-scout-local
+# Install sccache
+RUN wget https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
+    && tar -xzf sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
+    && rm -r sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
+    && cp sccache-v0.2.15-x86_64-unknown-linux-musl/sccache /usr/local/bin \
+    && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -7,7 +7,6 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-devel-${LINUX_VER}
 ARG RAPIDS_CHANNEL=rapidsai-nightly
 ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
-ARG SCCACHE_VERSION=0.2.15
 
 # Optional arguments
 ARG BUILD_STACK_VER=9.4.0
@@ -101,18 +100,13 @@ RUN gpuci_conda_retry install -y \
       codecov \
       mamba \
       rapids-scout-local
-# Install sccache
-RUN wget https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-    && tar -xzf sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-    && mv sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin \
-    && rm -rf sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/ \
-    && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
+      sccache \
       cudatoolkit=${CUDA_VER} \
       git \
       git-lfs \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -7,6 +7,7 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-devel-${LINUX_VER}
 ARG RAPIDS_CHANNEL=rapidsai-nightly
 ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
+ARG SCCACHE_VERSION=0.2.15
 
 # Optional arguments
 ARG BUILD_STACK_VER=9.4.0
@@ -101,10 +102,10 @@ RUN gpuci_conda_retry install -y \
       mamba \
       rapids-scout-local
 # Install sccache
-RUN wget https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
-    && tar -xzf sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz \
-    && mv sccache-v0.2.15-x86_64-unknown-linux-musl/sccache /usr/local/bin \
-    && rm -rf sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz sccache-v0.2.15-x86_64-unknown-linux-musl/ \
+RUN wget https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz \
+    && tar -xzf sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz \
+    && mv sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin \
+    && rm -rf sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/ \
     && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -7,6 +7,7 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-devel-${LINUX_VER}
 ARG RAPIDS_CHANNEL=rapidsai-nightly
 ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
+ARG SCCACHE_VERSION=0.2.15
 
 # Optional arguments
 ARG BUILD_STACK_VER=9.4.0
@@ -99,10 +100,10 @@ RUN gpuci_conda_retry install -y \
       mamba \
       rapids-scout-local
 # Install sccache
-RUN wget https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
-    && tar -xzf sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
-    && mv sccache-v0.2.15-aarch64-unknown-linux-musl/sccache /usr/local/bin \
-    && rm -rf sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz sccache-v0.2.15-aarch64-unknown-linux-musl/ \
+RUN wget https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz \
+    && tar -xzf sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz \
+    && mv sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl/sccache /usr/local/bin \
+    && rm -rf sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl/ \
     && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -101,8 +101,8 @@ RUN gpuci_conda_retry install -y \
 # Install sccache
 RUN wget https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
     && tar -xzf sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
-    && rm -r sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
-    && cp sccache-v0.2.15-aarch64-unknown-linux-musl/sccache /usr/local/bin \
+    && mv sccache-v0.2.15-aarch64-unknown-linux-musl/sccache /usr/local/bin \
+    && rm -rf sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz sccache-v0.2.15-aarch64-unknown-linux-musl/ \
     && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -7,7 +7,6 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-devel-${LINUX_VER}
 ARG RAPIDS_CHANNEL=rapidsai-nightly
 ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
-ARG SCCACHE_VERSION=0.2.15
 
 # Optional arguments
 ARG BUILD_STACK_VER=9.4.0
@@ -99,12 +98,6 @@ RUN gpuci_conda_retry install -y \
       jq \
       mamba \
       rapids-scout-local
-# Install sccache
-RUN wget https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz \
-    && tar -xzf sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz \
-    && mv sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl/sccache /usr/local/bin \
-    && rm -rf sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl/ \
-    && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default
 # TODO: Remove -c rapidsai-nightly
@@ -113,6 +106,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c conda-forge \
       -c gpuci \
       -c rapidsai-nightly \
+      sccache \
       cudatoolkit=${CUDA_VER} \
       git \
       git-lfs \

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -98,6 +98,12 @@ RUN gpuci_conda_retry install -y \
       jq \
       mamba \
       rapids-scout-local
+# Install sccache
+RUN wget https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
+    && tar -xzf sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
+    && rm -r sccache-v0.2.15-aarch64-unknown-linux-musl.tar.gz \
+    && cp sccache-v0.2.15-aarch64-unknown-linux-musl/sccache /usr/local/bin \
+    && chmod +x /usr/local/bin/sccache
 
 # Create `rapids` conda env and make default
 # TODO: Remove -c rapidsai-nightly


### PR DESCRIPTION
This PR installs `sccache` in our ci images as part of efforts to deprecate project-flash.