### PR TITLE
remove gpuci-ccache

### DIFF
--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -100,8 +100,7 @@ RUN conda install -y gpuci-tools \
 RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
-      mamba \
-      rapids-scout-local
+      mamba
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -80,8 +80,7 @@ RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
       jq \
-      mamba \
-      rapids-scout-local
+      mamba
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -98,8 +98,7 @@ RUN conda install -y gpuci-tools \
 RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
-      mamba \
-      rapids-scout-local
+      mamba
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -96,8 +96,7 @@ RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
       jq \
-      mamba \
-      rapids-scout-local
+      mamba
 
 # Create `rapids` conda env and make default
 # TODO: Remove -c rapidsai-nightly


### PR DESCRIPTION
The `rapids-scout-local` is only present in our environment because it installs `gpuci-ccache` as a dependency. Since we're getting rid of `ccache` as part of efforts to deprecate project flash, we're removing both packages.