### PR TITLE
Add cmake vars

### DIFF
--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -25,6 +25,11 @@ ENV NVCC=/usr/local/cuda/bin/nvcc
 ENV CUDAToolkit_ROOT=/usr/local/cuda
 ENV CUDACXX=/usr/local/cuda/bin/nvcc 
 
+# Add sccache variables
+ENV CMAKE_CUDA_COMPILER_LAUNCHER=sccache
+ENV CMAKE_CXX_COMPILER_LAUNCHER=sccache
+ENV CMAKE_C_COMPILER_LAUNCHER=sccache
+
 # Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]
 

--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -21,6 +21,9 @@ ENV CXX=/usr/bin/g++
 ENV CUDAHOSTCXX=/usr/bin/g++
 ENV CUDA_HOME=/usr/local/cuda
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
+ENV NVCC=/usr/local/cuda/bin/nvcc
+ENV CUDAToolkit_ROOT=/usr/local/cuda
+ENV CUDACXX=/usr/local/cuda/bin/nvcc 
 
 # Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -28,6 +28,11 @@ ENV NVCC=/usr/local/cuda/bin/nvcc
 ENV CUDAToolkit_ROOT=/usr/local/cuda
 ENV CUDACXX=/usr/local/cuda/bin/nvcc 
 
+# Add sccache variables
+ENV CMAKE_CUDA_COMPILER_LAUNCHER=sccache
+ENV CMAKE_CXX_COMPILER_LAUNCHER=sccache
+ENV CMAKE_C_COMPILER_LAUNCHER=sccache
+
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc
 

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -24,6 +24,9 @@ ENV CUDAHOSTCXX=${GCC9_DIR}/bin/g++
 ENV CUDA_HOME=/usr/local/cuda
 ENV LD_LIBRARY_PATH=${GCC9_DIR}/lib64:$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
 ENV PATH=${GCC9_DIR}/bin:${BINUTILS_DIR}/bin:/usr/lib64/openmpi/bin:$PATH
+ENV NVCC=/usr/local/cuda/bin/nvcc
+ENV CUDAToolkit_ROOT=/usr/local/cuda
+ENV CUDACXX=/usr/local/cuda/bin/nvcc 
 
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -23,6 +23,10 @@ ENV CUDAHOSTCXX=${GCC9_DIR}/bin/g++
 ENV CUDA_HOME=/usr/local/cuda
 ENV LD_LIBRARY_PATH=${GCC9_DIR}/lib64:$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
 ENV PATH=${GCC9_DIR}/bin:/usr/lib64/openmpi/bin:$PATH
+ENV NVCC=/usr/local/cuda/bin/nvcc
+ENV CUDAToolkit_ROOT=/usr/local/cuda
+ENV CUDACXX=/usr/local/cuda/bin/nvcc 
+
 
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -27,6 +27,11 @@ ENV NVCC=/usr/local/cuda/bin/nvcc
 ENV CUDAToolkit_ROOT=/usr/local/cuda
 ENV CUDACXX=/usr/local/cuda/bin/nvcc 
 
+# Add sccache variables
+ENV CMAKE_CUDA_COMPILER_LAUNCHER=sccache
+ENV CMAKE_CXX_COMPILER_LAUNCHER=sccache
+ENV CMAKE_C_COMPILER_LAUNCHER=sccache
+
 
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -24,6 +24,11 @@ ENV NVCC=/usr/local/cuda/bin/nvcc
 ENV CUDAToolkit_ROOT=/usr/local/cuda
 ENV CUDACXX=/usr/local/cuda/bin/nvcc 
 
+# Add sccache variables
+ENV CMAKE_CUDA_COMPILER_LAUNCHER=sccache
+ENV CMAKE_CXX_COMPILER_LAUNCHER=sccache
+ENV CMAKE_C_COMPILER_LAUNCHER=sccache
+
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc
 

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -20,6 +20,9 @@ ENV CXX=/usr/bin/g++
 ENV CUDAHOSTCXX=/usr/bin/g++
 ENV CUDA_HOME=/usr/local/cuda
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
+ENV NVCC=/usr/local/cuda/bin/nvcc
+ENV CUDAToolkit_ROOT=/usr/local/cuda
+ENV CUDACXX=/usr/local/cuda/bin/nvcc 
 
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -24,6 +24,11 @@ ENV NVCC=/usr/local/cuda/bin/nvcc
 ENV CUDAToolkit_ROOT=/usr/local/cuda
 ENV CUDACXX=/usr/local/cuda/bin/nvcc 
 
+# Add sccache variables
+ENV CMAKE_CUDA_COMPILER_LAUNCHER=sccache
+ENV CMAKE_CXX_COMPILER_LAUNCHER=sccache
+ENV CMAKE_C_COMPILER_LAUNCHER=sccache
+
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc
 

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -20,6 +20,9 @@ ENV CXX=/usr/bin/g++
 ENV CUDAHOSTCXX=/usr/bin/g++
 ENV CUDA_HOME=/usr/local/cuda
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
+ENV NVCC=/usr/local/cuda/bin/nvcc
+ENV CUDAToolkit_ROOT=/usr/local/cuda
+ENV CUDACXX=/usr/local/cuda/bin/nvcc 
 
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc


### PR DESCRIPTION
This PR adds the following `cmake` environment variables to our images so that users won't have to manually set them if they want to replicate our builds locally using our CI containers.
```
NVCC
CUDAToolkit_ROOT
CUDACXX
```

PR also adds the `cmake` `COMPILER_LAUNCHER` variables to the images. 