### PR TITLE
Install boa in rapidsai images

### DIFF
--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -101,6 +101,7 @@ RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
       mamba \
+      boa \
       rapids-scout-local
 
 # Create `rapids` conda env and make default

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -85,6 +85,7 @@ RUN gpuci_conda_retry install -y \
       codecov \
       jq \
       mamba \
+      boa \
       rapids-scout-local
 
 # Create `rapids` conda env and make default

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -99,6 +99,7 @@ RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
       mamba \
+      boa \
       rapids-scout-local
 
 # Create `rapids` conda env and make default

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -97,6 +97,7 @@ RUN gpuci_conda_retry install -y \
       codecov \
       jq \
       mamba \
+      boa \
       rapids-scout-local
 
 # Create `rapids` conda env and make default


### PR DESCRIPTION
Install `boa` in `gpuci/rapidsai` images to be able to use `mambabuild` to build packages