### PR TITLE
Review conda envs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ RUN source activate base \
 ## Enables "source activate conda"
 SHELL ["/bin/bash", "-c"]
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+ENTRYPOINT [ "/tini", "--" ]
 CMD [ "/bin/bash" ]
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,11 +75,9 @@ ARG LIB_NG_VERSION=7.5.0
 
 # Set environment
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
-ENV PATH=${PATH}:/conda/bin
 
 # Create a dev conda env
-RUN conda activate base \
-    && conda create --no-default-packages --override-channels -n dev \
+RUN conda create --no-default-packages --override-channels -n dev \
       -c nvidia \
       -c conda-forge \
       cudatoolkit=${CUDA_VER} \
@@ -89,13 +87,10 @@ RUN conda activate base \
       python=${PYTHON_VERSION} \
       #TODO: Add additional conda packages here
     && conda clean -afy \
-    && sed -i 's/conda activate base/conda activate dev/g' ~/.bashrc \
+    && sed -i 's/conda activate base/conda activate dev/g' /etc/profile.d/conda.sh \
     && chmod -R ugo+w /opt/conda
 
-## Enables "conda activate"
-SHELL ["/bin/bash", "--login", "-c"]
-
-ENTRYPOINT [ "/tini", "--" ]
+ENTRYPOINT [ "/tini", "--", "/bin/bash", "--login", "-c" ]
 CMD [ "/bin/bash" ]
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
 ENV PATH=${PATH}:/conda/bin
 
 # Create a dev conda env
-RUN source activate base \
+RUN conda activate base \
     && conda create --no-default-packages --override-channels -n dev \
       -c nvidia \
       -c conda-forge \
@@ -92,8 +92,8 @@ RUN source activate base \
     && sed -i 's/conda activate base/conda activate dev/g' ~/.bashrc \
     && chmod -R ugo+w /opt/conda
 
-## Enables "source activate conda"
-SHELL ["/bin/bash", "-c"]
+## Enables "conda activate"
+SHELL ["/bin/bash", "--login", "-c"]
 
 ENTRYPOINT [ "/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/miniconda-cuda-driver/Dockerfile
+++ b/miniconda-cuda-driver/Dockerfile
@@ -10,8 +10,7 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}
 ARG DRIVER_VER="450"
 
 # Add core tools to base env
-RUN source activate base \
-    && conda install -k -y --override-channels -c gpuci gpuci-tools \
+RUN conda install -k -y --override-channels -c gpuci gpuci-tools \
     && gpuci_conda_retry install -k -y -c conda-forge \
       anaconda-client \
       codecov \

--- a/miniconda-cuda-driver/centos7.Dockerfile
+++ b/miniconda-cuda-driver/centos7.Dockerfile
@@ -10,8 +10,7 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}
 ARG DRIVER_VER="440"
 
 # Add core tools to base env
-RUN source activate base \
-    && conda install -k -y --override-channels -c gpuci gpuci-tools \
+RUN conda install -k -y --override-channels -c gpuci gpuci-tools \
     && gpuci_conda_retry install -k -y -c conda-forge \
       anaconda-client \
       codecov \

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -21,8 +21,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ## A lot of scripts and conda recipes depend on this env var
 ENV CUDA_VERSION=${FULL_CUDA_VER}
 
-# Enables "source activate conda"
-SHELL ["/bin/bash", "-c"]
+# Enables "conda activate"
+SHELL ["/bin/bash", "--login", "-c"]
 
 # Update and add pkgs for Ubuntu, also generate locales for 'en_US.UTF-8'
 RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
@@ -93,9 +93,7 @@ RUN wget --quiet ${MINICONDA_URL} -O /miniconda.sh \
     && rm -f /miniconda.sh \
     && echo "conda ${CONDA_VER}" >> /opt/conda/conda-meta/pinned \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
-    && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
-    && echo "conda activate base" >> ~/.bashrc \
-    && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/skel/.bashrc \
+    && echo "conda activate base" >> /etc/profile.d/conda.sh \
     && echo "auto_update_conda: False" >> /opt/conda/.condarc \
     && ln -s /opt/conda /conda
 

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -100,14 +100,15 @@ RUN wget --quiet ${MINICONDA_URL} -O /miniconda.sh \
     && echo "auto_update_conda: False" >> /opt/conda/.condarc \
     && ln -s /opt/conda /conda
 
-# Install tini for init
-RUN conda install -k -y tini \
-    || conda install -k -y tini
+# Install tini
+ARG TINI_VER=v0.19.0
+RUN wget "https://github.com/krallin/tini/releases/download/${TINI_VER}/tini-amd64" -O /tini \
+    && chmod +x /tini
 
 # Clean up conda and set permissions for all users
 RUN chmod -R ugo+w /opt/conda \
     && /opt/conda/bin/conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+ENTRYPOINT [ "/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -107,5 +107,5 @@ RUN chmod -R ugo+w /opt/conda \
     && /opt/conda/bin/conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/tini", "--" ]
+ENTRYPOINT ["/tini", "--", "/bin/bash", "--login", "-c"]
 CMD [ "/bin/bash" ]

--- a/miniconda-cuda/Dockerfile
+++ b/miniconda-cuda/Dockerfile
@@ -15,7 +15,6 @@ ARG MINICONDA_URL=http://repo.anaconda.com/miniconda/Miniconda3-py38_${CONDA_VER
 # Set environment
 ENV CONDA_DIR=/opt/conda
 ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LANGUAGE=en_US:en
-ENV PATH=${CONDA_DIR}/bin:${PATH}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set CUDA_VERSION as in some 'nvidia/cuda' images this is not set

--- a/miniforge-cuda-driver/ubuntu.Dockerfile
+++ b/miniforge-cuda-driver/ubuntu.Dockerfile
@@ -11,8 +11,7 @@ ARG DRIVER_VER="450"
 ARG LINUX_VER
 
 # Add core tools to base env
-RUN source activate base \
-    && conda install -k -y --override-channels -c gpuci gpuci-tools \
+RUN conda install -k -y --override-channels -c gpuci gpuci-tools \
     && gpuci_conda_retry install -k -y -c conda-forge \
       anaconda-client \
       codecov \

--- a/miniforge-cuda-l4t/Dockerfile
+++ b/miniforge-cuda-l4t/Dockerfile
@@ -14,7 +14,6 @@ ARG CONDA_VER=4.8.3-5
 ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${CONDA_VER}/Miniforge3-${CONDA_VER}-Linux-${ARCH_TYPE}.sh
 
 # Set environment
-ENV PATH=/opt/conda/bin:${PATH}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set CUDA_VERSION as in some 'nvidia/cuda' images this is not set

--- a/miniforge-cuda-l4t/Dockerfile
+++ b/miniforge-cuda-l4t/Dockerfile
@@ -94,11 +94,12 @@ RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
     && echo "ssl_verify: False" >> /opt/conda/.condarc \
     && ln -s /opt/conda /conda
 
-# Install tini for init
-RUN conda install -k -y tini \
-    || conda install -k -y tini
+# Install tini
+ARG TINI_VER=v0.19.0
+RUN wget "https://github.com/krallin/tini/releases/download/${TINI_VER}/tini-arm64" -O /tini \
+    && chmod +x /tini
 
 RUN chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+ENTRYPOINT [ "/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/miniforge-cuda-l4t/Dockerfile
+++ b/miniforge-cuda-l4t/Dockerfile
@@ -20,8 +20,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ## A lot of scripts and conda recipes depend on this env var
 ENV CUDA_VERSION=${FULL_CUDA_VER}
 
-# Enables "source activate conda"
-SHELL ["/bin/bash", "-c"]
+# Enables "conda activate"
+SHELL ["/bin/bash", "--login", "-c"]
 
 # Update and add pkgs for Ubuntu, also generate locales for 'en_US.UTF-8'
 RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
@@ -86,9 +86,7 @@ RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
     && rm -f /miniforge.sh \
     && /opt/conda/bin/conda clean -tipsy \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
-    && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
-    && echo "conda activate base" >> ~/.bashrc \
-    && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/skel/.bashrc \
+    && echo "conda activate base" >> /etc/profile.d/conda.sh \
     && echo "auto_update_conda: False" >> /opt/conda/.condarc \
     && echo "ssl_verify: False" >> /opt/conda/.condarc \
     && ln -s /opt/conda /conda

--- a/miniforge-cuda-l4t/Dockerfile
+++ b/miniforge-cuda-l4t/Dockerfile
@@ -98,5 +98,5 @@ RUN wget "https://github.com/krallin/tini/releases/download/${TINI_VER}/tini-arm
 
 RUN chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/tini", "--" ]
+ENTRYPOINT ["/tini", "--", "/bin/bash", "--login", "-c"]
 CMD [ "/bin/bash" ]

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -14,7 +14,6 @@ ARG CONDA_VER=4.8.3-5
 ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${CONDA_VER}/Miniforge3-${CONDA_VER}-Linux-${ARCH_TYPE}.sh
 
 # Set environment
-ENV PATH=/opt/conda/bin:${PATH}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set CUDA_VERSION as in some 'nvidia/cuda' images this is not set

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -108,5 +108,5 @@ RUN chmod -R ugo+w /opt/conda \
     && /opt/conda/bin/conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/tini", "--" ]
+ENTRYPOINT ["/tini", "--", "/bin/bash", "--login", "-c"]
 CMD [ "/bin/bash" ]

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -94,14 +94,22 @@ RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
     && echo "ssl_verify: False" >> /opt/conda/.condarc \
     && ln -s /opt/conda /conda
 
-# Install tini for init
-RUN conda install -k -y tini \
-    || conda install -k -y tini
+# Install tini
+ARG TINI_VER=v0.19.0
+RUN if [ "${ARCH_TYPE}" = "x86_64" ]; then \
+    wget --quiet "https://github.com/krallin/tini/releases/download/${TINI_VER}/tini-amd64" -O /tini; \
+  elif [ "${ARCH_TYPE}" = "aarch64" ]; then \
+    wget --quiet "https://github.com/krallin/tini/releases/download/${TINI_VER}/tini-arm64" -O /tini; \
+  else \
+    echo "Unsupported arch" \
+    && exit 1; \
+  fi \
+  && chmod +x /tini
 
 # Clean up conda and set permissions for all users
 RUN chmod -R ugo+w /opt/conda \
     && /opt/conda/bin/conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+ENTRYPOINT [ "/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -20,8 +20,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ## A lot of scripts and conda recipes depend on this env var
 ENV CUDA_VERSION=${FULL_CUDA_VER}
 
-# Enables "source activate conda"
-SHELL ["/bin/bash", "-c"]
+# Enables "conda activate"
+SHELL ["/bin/bash", "--login", "-c"]
 
 # Update and add pkgs for Ubuntu, also generate locales for 'en_US.UTF-8'
 RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
@@ -86,9 +86,7 @@ RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
     && /bin/bash /miniforge.sh -b -p /opt/conda \
     && rm -f /miniforge.sh \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
-    && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
-    && echo "conda activate base" >> ~/.bashrc \
-    && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/skel/.bashrc \
+    && echo "conda activate base" >> /etc/profile.d/conda.sh \
     && echo "auto_update_conda: False" >> /opt/conda/.condarc \
     && echo "ssl_verify: False" >> /opt/conda/.condarc \
     && ln -s /opt/conda /conda

--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -118,5 +118,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+ENTRYPOINT [ "/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -22,9 +22,6 @@ ENV CUDAHOSTCXX=/usr/bin/g++
 ENV CUDA_HOME=/usr/local/cuda
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
 
-# Enables "source activate conda"
-SHELL ["/bin/bash", "-c"]
-
 # Add a condarc for channels and override settings
 RUN if [ "${RAPIDS_CHANNEL}" == "rapidsai" ] ; then \
       echo -e "\
@@ -108,7 +105,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       python="${PYTHON_VER}" \
       "python_abi=*=*cp*" \
       "setuptools>50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+    && sed -i 's/conda activate base/conda activate rapids/g' /etc/profile.d/conda.sh
 
 # Clean up pkgs to reduce image size and chmod for all users
 RUN chmod -R ugo+w /opt/conda \

--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -93,23 +93,20 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv
 RUN conda install -y gpuci-tools \
     || conda install -y gpuci-tools
 
-RUN gpuci_conda_retry install -y \
-      anaconda-client \
-      codecov
-# FIXME: Install rapids-scout-local
-#      rapids-scout-local
-
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
+      anaconda-client \
+      codecov \
       git \
       gpuci-tools \
-      libgcc-ng=${BUILD_STACK_VER} \
-      libstdcxx-ng=${BUILD_STACK_VER} \
-      python=${PYTHON_VER} \
-      'python_abi=*=*cp*' \
+      libgcc-ng="${BUILD_STACK_VER}" \
+      libstdcxx-ng="${BUILD_STACK_VER}" \
+      mamba \
+      python="${PYTHON_VER}" \
+      "python_abi=*=*cp*" \
       "setuptools>50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 

--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -112,5 +112,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/tini", "--" ]
+ENTRYPOINT ["/tini", "--", "/bin/bash", "--login", "-c"]
 CMD [ "/bin/bash" ]

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -15,9 +15,6 @@ ARG BUILD_STACK_VER=9.4.0
 # Capture argument used for FROM
 ARG CUDA_VER
 
-# Enables "source activate conda"
-SHELL ["/bin/bash", "-c"]
-
 # Add a condarc for channels and override settings
 RUN if [ "${RAPIDS_CHANNEL}" == "rapidsai" ] ; then \
       echo -e "\
@@ -60,7 +57,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       python="${PYTHON_VER}" \
       "python_abi=*=*cp*" \
       "setuptools>50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+    && sed -i 's/conda activate base/conda activate rapids/g' /etc/profile.d/conda.sh
 
 # For `runtime` images install notebook env meta-pkg
 #

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -77,5 +77,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/tini", "--" ]
+ENTRYPOINT ["/tini", "--", "/bin/bash", "--login", "-c"]
 CMD [ "/bin/bash" ]

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -45,19 +45,20 @@ channels: \n\
     fi
 
 # Create rapids conda env and make default
-RUN conda install -y gpuci-tools mamba \
-    || conda install -y gpuci-tools mamba
+RUN conda install -y gpuci-tools \
+    || conda install -y gpuci-tools
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
-      cudatoolkit=${CUDA_VER} \
+      cudatoolkit="${CUDA_VER}" \
       git \
       gpuci-tools \
-      libgcc-ng=${BUILD_STACK_VER} \
-      libstdcxx-ng=${BUILD_STACK_VER} \
-      python=${PYTHON_VER} \
-      'python_abi=*=*cp*' \
+      libgcc-ng="${BUILD_STACK_VER}" \
+      libstdcxx-ng="${BUILD_STACK_VER}" \
+      mamba \
+      python="${PYTHON_VER}" \
+      "python_abi=*=*cp*" \
       "setuptools>50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -79,5 +79,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+ENTRYPOINT [ "/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -97,26 +97,25 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 # Add core tools to base env
 RUN conda install -y gpuci-tools \
     || conda install -y gpuci-tools
-RUN gpuci_conda_retry install -y \
-      anaconda-client \
-      codecov \
-      mamba \
-      rapids-scout-local
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
-      sccache \
-      cudatoolkit=${CUDA_VER} \
+      anaconda-client \
+      codecov \
+      cudatoolkit="${CUDA_VER}" \
       git \
       git-lfs \
       gpuci-tools \
-      libgcc-ng=${BUILD_STACK_VER} \
-      libstdcxx-ng=${BUILD_STACK_VER} \
-      python=${PYTHON_VER} \
-      'python_abi=*=*cp*' \
+      libgcc-ng="${BUILD_STACK_VER}" \
+      libstdcxx-ng="${BUILD_STACK_VER}" \
+      mamba \
+      python="${PYTHON_VER}" \
+      "python_abi=*=*cp*" \
+      rapids-scout-local \
+      sccache \
       "setuptools>50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -138,5 +138,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+ENTRYPOINT [ "/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -28,9 +28,6 @@ ENV PATH=${GCC9_DIR}/bin:${BINUTILS_DIR}/bin:/usr/lib64/openmpi/bin:$PATH
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc
 
-# Enables "source activate conda"
-SHELL ["/bin/bash", "-c"]
-
 # Install gcc9 from prebuilt tarball
 RUN wget --quiet ${GCC9_URL} -O /gcc9.tgz \
     && tar xzvf /gcc9.tgz \
@@ -114,10 +111,9 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       mamba \
       python="${PYTHON_VER}" \
       "python_abi=*=*cp*" \
-      rapids-scout-local \
       sccache \
       "setuptools>50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+    && sed -i 's/conda activate base/conda activate rapids/g' /etc/profile.d/conda.sh
 
 # Install build/doc/notebook env meta-pkgs
 #

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -133,5 +133,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/tini", "--" ]
+ENTRYPOINT ["/tini", "--", "/bin/bash", "--login", "-c"]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -27,9 +27,6 @@ ENV PATH=${GCC9_DIR}/bin:/usr/lib64/openmpi/bin:$PATH
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc
 
-# Enables "source activate conda"
-SHELL ["/bin/bash", "-c"]
-
 # Fix CentOS8 EOL
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* 
@@ -98,10 +95,9 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       mamba \
       python="${PYTHON_VER}" \
       "python_abi=*=*cp*" \
-      rapids-scout-local \
       sccache \
       "setuptools>50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+    && sed -i 's/conda activate base/conda activate rapids/g' /etc/profile.d/conda.sh
 
 # Install build/doc/notebook env meta-pkgs
 #

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -125,5 +125,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+ENTRYPOINT [ "/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -80,27 +80,26 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv
 # Add core tools to base env
 RUN conda install -y gpuci-tools \
     || conda install -y gpuci-tools
-RUN gpuci_conda_retry install -y \
-      anaconda-client \
-      codecov \
-      jq \
-      mamba \
-      rapids-scout-local
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
-      sccache \
-      cudatoolkit=${CUDA_VER} \
+      anaconda-client \
+      codecov \
+      cudatoolkit="${CUDA_VER}" \
       git \
       git-lfs \
       gpuci-tools \
-      libgcc-ng=${BUILD_STACK_VER} \
-      libstdcxx-ng=${BUILD_STACK_VER} \
-      python=${PYTHON_VER} \
-      'python_abi=*=*cp*' \
+      jq \
+      libgcc-ng="${BUILD_STACK_VER}" \
+      libstdcxx-ng="${BUILD_STACK_VER}" \
+      mamba \
+      python="${PYTHON_VER}" \
+      "python_abi=*=*cp*" \
+      rapids-scout-local \
+      sccache \
       "setuptools>50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -120,5 +120,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/tini", "--" ]
+ENTRYPOINT ["/tini", "--", "/bin/bash", "--login", "-c"]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -24,9 +24,6 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc
 
-# Enables "source activate conda"
-SHELL ["/bin/bash", "-c"]
-
 # Add a condarc for channels and override settings
 RUN if [ "${RAPIDS_CHANNEL}" == "rapidsai" ] ; then \
       echo -e "\
@@ -112,10 +109,9 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       mamba \
       python="${PYTHON_VER}" \
       "python_abi=*=*cp*" \
-      rapids-scout-local \
       sccache \
       "setuptools>50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+    && sed -i 's/conda activate base/conda activate rapids/g' /etc/profile.d/conda.sh
 
 # Install build/doc/notebook env meta-pkgs
 #

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -95,26 +95,25 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 # Add core tools to base env
 RUN conda install -y gpuci-tools \
     || conda install -y gpuci-tools
-RUN gpuci_conda_retry install -y \
-      anaconda-client \
-      codecov \
-      mamba \
-      rapids-scout-local
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
-      sccache \
-      cudatoolkit=${CUDA_VER} \
+      anaconda-client \
+      codecov \
+      cudatoolkit="${CUDA_VER}" \
       git \
       git-lfs \
       gpuci-tools \
-      libgcc-ng=${BUILD_STACK_VER} \
-      libstdcxx-ng=${BUILD_STACK_VER} \
-      python=${PYTHON_VER} \
-      'python_abi=*=*cp*' \
+      libgcc-ng="${BUILD_STACK_VER}" \
+      libstdcxx-ng="${BUILD_STACK_VER}" \
+      mamba \
+      python="${PYTHON_VER}" \
+      "python_abi=*=*cp*" \
+      rapids-scout-local \
+      sccache \
       "setuptools>50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -131,5 +131,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/tini", "--" ]
+ENTRYPOINT ["/tini", "--", "/bin/bash", "--login", "-c"]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -136,5 +136,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+ENTRYPOINT [ "/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -92,29 +92,26 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv
 # Add core tools to base env
 RUN conda install -y gpuci-tools \
     || conda install -y gpuci-tools
-RUN gpuci_conda_retry install -y \
-      anaconda-client \
-      codecov \
-      jq \
-      mamba \
-      rapids-scout-local
 
 # Create `rapids` conda env and make default
-# TODO: Remove -c rapidsai-nightly
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
-      -c rapidsai-nightly \
-      sccache \
-      cudatoolkit=${CUDA_VER} \
+      anaconda-client \
+      codecov \
+      cudatoolkit="${CUDA_VER}" \
       git \
       git-lfs \
       gpuci-tools \
-      libgcc-ng=${BUILD_STACK_VER} \
-      libstdcxx-ng=${BUILD_STACK_VER} \
-      python=${PYTHON_VER} \
-      'python_abi=*=*cp*' \
+      jq \
+      libgcc-ng="${BUILD_STACK_VER}" \
+      libstdcxx-ng="${BUILD_STACK_VER}" \
+      mamba \
+      python="${PYTHON_VER}" \
+      "python_abi=*=*cp*" \
+      rapids-scout-local \
+      sccache \
       "setuptools>50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -134,5 +134,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--" ]
+ENTRYPOINT [ "/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -127,5 +127,5 @@ RUN chmod -R ugo+w /opt/conda \
     && conda clean -tipy \
     && chmod -R ugo+w /opt/conda
 
-ENTRYPOINT [ "/tini", "--" ]
+ENTRYPOINT ["/tini", "--", "/bin/bash", "--login", "-c"]
 CMD [ "/bin/bash" ]

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -24,9 +24,6 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
 # Set variable for mambarc
 ENV CONDARC=/opt/conda/.condarc
 
-# Enables "source activate conda"
-SHELL ["/bin/bash", "-c"]
-
 # Add a condarc for channels and override settings
 RUN if [ "${RAPIDS_CHANNEL}" == "rapidsai" ] ; then \
       echo -e "\
@@ -110,10 +107,9 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       mamba \
       python="${PYTHON_VER}" \
       "python_abi=*=*cp*" \
-      rapids-scout-local \
       sccache \
       "setuptools>50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+    && sed -i 's/conda activate base/conda activate rapids/g' /etc/profile.d/conda.sh
 
 # Install build/doc/notebook env meta-pkgs
 #


### PR DESCRIPTION
This PR tries to review our conda envs in the `gpuci` images:
- Install `tini` system-wide and not in any conda env
- Remove `PATH` modification to include `base` env binaries
- Install all conda packages to `rapids` env
- Write conda activation scripts in `/etc/profile.d/conda.sh`
- Fix entrypoint and shell to act as login shell and load `/etc/profile.d/conda.sh` to activate conda envs

We need to update `rapidsai/rapidsai` images to use the new `tini` path

I would recommend to review commit by commit.