### PR TITLE
Remove `BUILD_STACK_VER` from Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,6 @@ release images and as the base for `gpuci/rapidsai-driver` and `gpuci/rapidsai-d
   - `RAPIDS_CHANNEL` - `conda` channel to use for install of integration pkgs
     - `rapidsai` for stable; `rapidsai-nightly` for nightly
   - `RAPIDS_VER` - Major and minor version to use for packages (e.g. `21.06`)
-  - `BUILD_STACK_VER` - Specifies the `conda-forge` version of build stack to install
-    - Default - `9.4.0` for packages `libgcc-ng` & `libstdcxx-ng`
 - Base image
   - `FROM gpuci/miniconda-cuda:${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}`
 - Purpose

--- a/ci/axis/rapidsai-arm64.yml
+++ b/ci/axis/rapidsai-arm64.yml
@@ -37,9 +37,6 @@ PYTHON_VER:
   - 3.8
   - 3.9
 
-BUILD_STACK_VER:
-  - 9.4.0
-
 exclude:
   - IMAGE_TYPE: base
     DOCKER_FILE: devel.arm64.Dockerfile

--- a/ci/axis/rapidsai-l4t.yml
+++ b/ci/axis/rapidsai-l4t.yml
@@ -30,7 +30,4 @@ PYTHON_VER:
   - 3.8
   - 3.9
 
-BUILD_STACK_VER:
-  - 9.4.0
-
 exclude:

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -39,9 +39,6 @@ PYTHON_VER:
   - 3.8
   - 3.9
 
-BUILD_STACK_VER:
-  - 9.4.0
-
 exclude:
   - IMAGE_TYPE: base
     DOCKER_FILE: devel.Dockerfile

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -102,13 +102,6 @@ else
   echo "ARCH_TYPE is set to '$ARCH_TYPE', adding to build args..."
   BUILD_ARGS="${BUILD_ARGS} --build-arg ARCH_TYPE=${ARCH_TYPE}"
 fi
-# Check if BUILD_STACK_VER is set
-if [ -z "$BUILD_STACK_VER" ] ; then
-  echo "BUILD_STACK_VER is not set, skipping..."
-else
-  echo "BUILD_STACK_VER is set to '$BUILD_STACK_VER', adding to build args..."
-  BUILD_ARGS="${BUILD_ARGS} --build-arg BUILD_STACK_VER=${BUILD_STACK_VER}"
-fi
 
 # Ouput build config
 gpuci_logger "Build config info..."

--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -9,9 +9,6 @@ ARG RAPIDS_CHANNEL=rapidsai-nightly
 ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
 
-# Optional arguments
-ARG BUILD_STACK_VER=9.4.0
-
 # Capture argument used for FROM
 ARG CUDA_VER
 
@@ -114,8 +111,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       git \
       gpuci-tools \
-      libgcc-ng=${BUILD_STACK_VER} \
-      libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools>50" \

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -9,9 +9,6 @@ ARG RAPIDS_CHANNEL=rapidsai-nightly
 ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
 
-# Optional arguments
-ARG BUILD_STACK_VER=9.4.0
-
 # Capture argument used for FROM
 ARG CUDA_VER
 
@@ -54,8 +51,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       cudatoolkit=${CUDA_VER} \
       git \
       gpuci-tools \
-      libgcc-ng=${BUILD_STACK_VER} \
-      libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools>50" \

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -9,7 +9,6 @@ ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
 
 # Optional arguments
-ARG BUILD_STACK_VER=9.4.0
 ARG GCC9_URL=https://gpuci.s3.us-east-2.amazonaws.com/builds/gcc9.tgz
 ARG BINUTILS_DIR=/usr/local/binutils
 
@@ -120,8 +119,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       git \
       git-lfs \
       gpuci-tools \
-      libgcc-ng=${BUILD_STACK_VER} \
-      libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools>50" \

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -9,7 +9,6 @@ ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
 
 # Optional arguments
-ARG BUILD_STACK_VER=9.4.0
 ARG GCC9_URL=https://gpuci.s3.us-east-2.amazonaws.com/builds/gcc9-arm64.tgz
 
 # Capture argument used for FROM
@@ -105,8 +104,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       git \
       git-lfs \
       gpuci-tools \
-      libgcc-ng=${BUILD_STACK_VER} \
-      libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools>50" \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -8,9 +8,6 @@ ARG RAPIDS_CHANNEL=rapidsai-nightly
 ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
 
-# Optional arguments
-ARG BUILD_STACK_VER=9.4.0
-
 # Capture argument used for FROM
 ARG CUDA_VER
 
@@ -118,8 +115,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       git \
       git-lfs \
       gpuci-tools \
-      libgcc-ng=${BUILD_STACK_VER} \
-      libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools>50" \

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -8,9 +8,6 @@ ARG RAPIDS_CHANNEL=rapidsai-nightly
 ARG RAPIDS_VER=0.15
 ARG PYTHON_VER=3.7
 
-# Optional arguments
-ARG BUILD_STACK_VER=9.4.0
-
 # Capture argument used for FROM
 ARG CUDA_VER
 
@@ -118,8 +115,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       git \
       git-lfs \
       gpuci-tools \
-      libgcc-ng=${BUILD_STACK_VER} \
-      libstdcxx-ng=${BUILD_STACK_VER} \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools>50" \


### PR DESCRIPTION
This PR removes all instances of `BUILD_STACK_VER`, which is responsible for determining the `libgcc-ng` and `libstdcxx-ng` versions that are used in our images. There is already a version variable for this in the `integration` repo which is responsible for controlling the versions of these packages in `rapids-build-env`, so having them here just means unnecessary duplication.

This issue was discovered after https://github.com/rapidsai/integration/pull/410 was merged and we noticed that these images were not picking up the latest `rapids-build-env` package.