### PR TITLE
Prevent apt from installing gcc-11 in ubuntu devel images

### DIFF
--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -84,6 +84,9 @@ RUN apt-get update -y --fix-missing \
       tzdata \
       vim \
       zlib1g-dev \
+      cpp-9 \
+      gcc-9 \
+      gfortran-9 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -86,6 +86,9 @@ RUN apt-get update -y --fix-missing \
       tzdata \
       vim \
       zlib1g-dev \
+      cpp-9 \
+      gcc-9 \
+      gfortran-9 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
If we do not specify the `gcc-9` package when we install `openmpi` packages, `apt` is installing `gcc-11` instead of using `gcc-9`. Same for `cpp-9` and `gfortran-9`. By doing this, we are forcing `apt` to use `gcc-9` and not `gcc-11`