### PR TITLE
Resolve build issues in `devel` images

### DIFF
--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -111,7 +111,7 @@ RUN gpuci_conda_retry install -y \
       mamba
 
 # Create `rapids` conda env and make default
-RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
@@ -122,18 +122,14 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       gpuci-tools \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
-      "setuptools>50" \
+      setuptools=59.8.0 \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
 # Install build/doc/notebook env meta-pkgs
 #
-# Once installed remove the meta-pkg so dependencies can be freely updated &
-# the meta-pkg can be installed again with updates
-RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
-      rapids-build-env=${RAPIDS_VER} \
-      rapids-doc-env=${RAPIDS_VER} \
-      rapids-notebook-env=${RAPIDS_VER} \
-    && gpuci_conda_retry remove -y -n rapids --force-remove \
+# Don't actually install the meta-pkgs so dependencies can be 
+# freely updated & the meta-pkg can be installed again with updates
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed --only-deps \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -107,17 +107,14 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       gpuci-tools \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
-      "setuptools>50" \
+      setuptools=59.8.0 \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
 # Install build/doc/notebook env meta-pkgs
 #
-# Once installed remove the meta-pkg so dependencies can be freely updated &
-# the meta-pkg can be installed again with updates
-RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
-      rapids-build-env=${RAPIDS_VER} \
-      rapids-notebook-env=${RAPIDS_VER} \
-    && gpuci_conda_retry remove -y -n rapids --force-remove \
+# Don't actually install the meta-pkgs so dependencies can be 
+# freely updated & the meta-pkg can be installed again with updates
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed --only-deps \
       rapids-build-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}
 

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -110,7 +110,7 @@ RUN gpuci_conda_retry install -y \
       mamba
 
 # Create `rapids` conda env and make default
-RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
@@ -121,18 +121,14 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       gpuci-tools \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
-      "setuptools>50" \
+      setuptools=59.8.0 \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
 # Install build/doc/notebook env meta-pkgs
 #
-# Once installed remove the meta-pkg so dependencies can be freely updated &
-# the meta-pkg can be installed again with updates
-RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
-      rapids-build-env=${RAPIDS_VER} \
-      rapids-doc-env=${RAPIDS_VER} \
-      rapids-notebook-env=${RAPIDS_VER} \
-    && gpuci_conda_retry remove -y -n rapids --force-remove \
+# Don't actually install the meta-pkgs so dependencies can be 
+# freely updated & the meta-pkg can be installed again with updates
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed --only-deps \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -109,7 +109,7 @@ RUN gpuci_conda_retry install -y \
 
 # Create `rapids` conda env and make default
 # TODO: Remove -c rapidsai-nightly
-RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
@@ -121,17 +121,14 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       gpuci-tools \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
-      "setuptools>50" \
+      setuptools=59.8.0 \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
 
 # Install build/doc/notebook env meta-pkgs
 #
-# Once installed remove the meta-pkg so dependencies can be freely updated &
-# the meta-pkg can be installed again with updates
-RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
-      rapids-build-env=${RAPIDS_VER} \
-      rapids-notebook-env=${RAPIDS_VER} \
-    && gpuci_conda_retry remove -y -n rapids --force-remove \
+# Don't actually install the meta-pkgs so dependencies can be 
+# freely updated & the meta-pkg can be installed again with updates
+RUN gpuci_mamba_retry install -y -n rapids --freeze-installed --only-deps \
       rapids-build-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER}
 


### PR DESCRIPTION
This PR does a few things to resolve some of the build errors being encountered with dask-cuda using the `devel` images:

- switch from conda to mamba for the environment creation / update, as mamba successfully catches conflicts when using `--freeze-installed` that conda ignores
- add `--only-deps` flag for metapackage installs so we don't have to force uninstall them; this also reduces the number of conflicts we encounter from `--freeze-installed`
- resolve the single remaining conflict by pinning `setuptools=59.8.0` (though it might make more sense to constrain this more loosely)

cc @ajschmidt8 