### PR TITLE
Build `22.06` images

### DIFF
--- a/ci/axis/rapidsai-arm64.yml
+++ b/ci/axis/rapidsai-arm64.yml
@@ -14,6 +14,7 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '22.04'
+  - '22.06'
 
 RAPIDS_CHANNEL:
   - rapidsai-nightly

--- a/ci/axis/rapidsai-driver-arm64.yml
+++ b/ci/axis/rapidsai-driver-arm64.yml
@@ -12,6 +12,7 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '22.04'
+  - '22.06'
 
 CUDA_VER:
   - 11.5

--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -12,6 +12,7 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '22.04'
+  - '22.06'
 
 CUDA_VER:
   - 11.5

--- a/ci/axis/rapidsai-l4t.yml
+++ b/ci/axis/rapidsai-l4t.yml
@@ -12,6 +12,7 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '22.04'
+  - '22.06'
 
 RAPIDS_CHANNEL:
   - rapidsai-nightly

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -14,6 +14,7 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '22.04'
+  - '22.06'
 
 RAPIDS_CHANNEL:
   - rapidsai-nightly


### PR DESCRIPTION
This PR updates the axis files to build `22.06` images.