### PR TITLE
Fix miniforge CVEs

### DIFF
--- a/miniforge-cuda-driver/centos7.Dockerfile
+++ b/miniforge-cuda-driver/centos7.Dockerfile
@@ -15,7 +15,7 @@ RUN source activate base \
     && gpuci_conda_retry install -k -y -c conda-forge \
       anaconda-client \
       codecov \
-      conda-build=3.19.2 \
+      conda-build=3.20.4 \
       conda-verify \
       ripgrep \
     && chmod -R ugo+w /opt/conda

--- a/miniforge-cuda-driver/ubuntu.Dockerfile
+++ b/miniforge-cuda-driver/ubuntu.Dockerfile
@@ -16,7 +16,7 @@ RUN source activate base \
     && gpuci_conda_retry install -k -y -c conda-forge \
       anaconda-client \
       codecov \
-      conda-build=3.19.2 \
+      conda-build=3.20.4 \
       conda-verify \
       ripgrep \
     && chmod -R ugo+w /opt/conda

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -27,6 +27,7 @@ SHELL ["/bin/bash", "-c"]
 # Update and add pkgs for Ubuntu, also generate locales for 'en_US.UTF-8'
 RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
       apt-get update \
+      && apt-get upgrade -y \
       && apt-get install -y --no-install-recommends \
         autoconf \
         automake \

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -10,7 +10,7 @@ ARG LINUX_VER
 
 # Define versions and download locations
 ARG ARCH_TYPE=x86_64
-ARG CONDA_VER=4.8.3-5
+ARG CONDA_VER=4.10.3-10
 ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${CONDA_VER}/Miniforge3-${CONDA_VER}-Linux-${ARCH_TYPE}.sh
 
 # Set environment


### PR DESCRIPTION
- Upgrade conda version to `4.10.3-10`
- Force system upgrades for Ubuntu
- Bump conda-build to `3.20.4`