### PR TITLE
Add `libnuma`

### DIFF
--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -36,6 +36,8 @@ RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
         curl \
         git \
         locales \
+        libnuma1 \
+        libnuma-dev \
         patch \
         tzdata \
         unzip \
@@ -74,6 +76,8 @@ RUN if [ "${LINUX_VER:0:6}" == "centos" ] ; then \
         curl \
         git \
         make \
+        numactl-devel \
+        numactl-libs \
         patch \
         unzip \
         wget \


### PR DESCRIPTION
This PR adds `libnuma` to our CI images since they were accidentally omitted from the `miniforge-cuda` images.