### PR TITLE
curl sccache from github releases

### DIFF
--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -115,7 +115,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c nvidia \
       -c conda-forge \
       -c gpuci \
-      sccache \
       cudatoolkit=${CUDA_VER} \
       git \
       git-lfs \
@@ -124,6 +123,12 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       'python_abi=*=*cp*' \
       "setuptools>50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+
+# Install SCCACHE
+ARG SCCACHE_VERSION=0.2.15
+ARG SCCACHE_ARCH=x86_64
+ARG SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl.tar.gz"
+RUN curl -L ${SCCACHE_URL} | tar -C /usr/bin -zf - --wildcards --strip-components=1 -x */sccache && chmod +x /usr/bin/sccache
 
 # Install build/doc/notebook env meta-pkgs
 #

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -100,7 +100,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c nvidia \
       -c conda-forge \
       -c gpuci \
-      sccache \
       cudatoolkit=${CUDA_VER} \
       git \
       git-lfs \
@@ -109,6 +108,12 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       'python_abi=*=*cp*' \
       "setuptools>50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+
+# Install SCCACHE
+ARG SCCACHE_VERSION=0.2.15
+ARG SCCACHE_ARCH=aarch64
+ARG SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl.tar.gz"
+RUN curl -L ${SCCACHE_URL} | tar -C /usr/bin -zf - --wildcards --strip-components=1 -x */sccache && chmod +x /usr/bin/sccache
 
 # Install build/doc/notebook env meta-pkgs
 #

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -114,7 +114,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c nvidia \
       -c conda-forge \
       -c gpuci \
-      sccache \
       cudatoolkit=${CUDA_VER} \
       git \
       git-lfs \
@@ -123,6 +122,12 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       'python_abi=*=*cp*' \
       "setuptools>50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+
+# Install SCCACHE
+ARG SCCACHE_VERSION=0.2.15
+ARG SCCACHE_ARCH=x86_64
+ARG SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl.tar.gz"
+RUN curl -L ${SCCACHE_URL} | tar -C /usr/bin -zf - --wildcards --strip-components=1 -x */sccache && chmod +x /usr/bin/sccache
 
 # Install build/doc/notebook env meta-pkgs
 #

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -114,7 +114,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c conda-forge \
       -c gpuci \
       -c rapidsai-nightly \
-      sccache \
       cudatoolkit=${CUDA_VER} \
       git \
       git-lfs \
@@ -123,6 +122,12 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       'python_abi=*=*cp*' \
       "setuptools>50" \
     && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+
+# Install SCCACHE
+ARG SCCACHE_VERSION=0.2.15
+ARG SCCACHE_ARCH=aarch64
+ARG SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl.tar.gz"
+RUN curl -L ${SCCACHE_URL} | tar -C /usr/bin -zf - --wildcards --strip-components=1 -x */sccache && chmod +x /usr/bin/sccache
 
 # Install build/doc/notebook env meta-pkgs
 #


### PR DESCRIPTION
Don't use conda, install directly to /usr/bin to be in PATH

This can solve problems where the conda env bin is not in the PATH and sccache can't be found. Should solve recent cuCollections build problems