### PR TITLE
Upkeep/cuda signing keys

### DIFF
--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -26,9 +26,8 @@ SHELL ["/bin/bash", "-c"]
 
 # Update and add pkgs for Ubuntu, also generate locales for 'en_US.UTF-8'
 RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
-      apt-key del 7fa2af80 \
-      &&  wget https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/${ARCH_TYPE}/cuda-keyring_1.0-1_all.deb -O /tmp/cuda-keyring.deb \
-      && dpkg -i /tmp/cuda-keyring.deb \
+      apt-key del "7fa2af80" \
+      && apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/${ARCH_TYPE}/3bf863cc.pub" \
       && apt-get update \
       && apt-get upgrade -y \
       && apt-get install -y --no-install-recommends \

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -26,7 +26,10 @@ SHELL ["/bin/bash", "-c"]
 
 # Update and add pkgs for Ubuntu, also generate locales for 'en_US.UTF-8'
 RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
-      apt-get update \
+      apt-key del 7fa2af80 \
+      &&  wget https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/${ARCH_TYPE}/cuda-keyring_1.0-1_all.deb -O /tmp/cuda-keyring.deb \
+      && dpkg -i /tmp/cuda-keyring.deb \
+      && apt-get update \
       && apt-get upgrade -y \
       && apt-get install -y --no-install-recommends \
         autoconf \

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -26,8 +26,7 @@ SHELL ["/bin/bash", "-c"]
 
 # Update and add pkgs for Ubuntu, also generate locales for 'en_US.UTF-8'
 RUN if [ "${LINUX_VER:0:6}" == "ubuntu" ] ; then \
-      apt-key del "7fa2af80" \
-      && apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/${ARCH_TYPE}/3bf863cc.pub" \
+      apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_VER/./}/${ARCH_TYPE}/3bf863cc.pub" \
       && apt-get update \
       && apt-get upgrade -y \
       && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This applies the recommended workaround for the CUDA toolkit signing key rotation - it should unblock the other PRs that are in-flight (to avoid waiting for the upstream containers to be fixed).

This workaround can (and should) be removed some day when all the upstream containers are fixed.