### PR TITLE
Add `gpuci-tools` to system `PATH`

### DIFF
--- a/miniforge-cuda-driver/centos7.Dockerfile
+++ b/miniforge-cuda-driver/centos7.Dockerfile
@@ -10,8 +10,9 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}
 ARG DRIVER_VER="440"
 
 # Add core tools to base env
+RUN wget https://github.com/rapidsai/gpuci-tools/releases/latest/download/tools.tar.gz -O - \
+    | tar -xz -C /usr/local/bin
 RUN source activate base \
-    && conda install -k -y --override-channels -c gpuci gpuci-tools \
     && gpuci_conda_retry install -k -y -c conda-forge \
       anaconda-client \
       codecov \

--- a/miniforge-cuda-driver/ubuntu.Dockerfile
+++ b/miniforge-cuda-driver/ubuntu.Dockerfile
@@ -10,9 +10,11 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VER}
 ARG DRIVER_VER="450"
 ARG LINUX_VER
 
+RUN wget https://github.com/rapidsai/gpuci-tools/releases/latest/download/tools.tar.gz -O - \
+    | tar -xz -C /usr/local/bin
+
 # Add core tools to base env
 RUN source activate base \
-    && conda install -k -y --override-channels -c gpuci gpuci-tools \
     && gpuci_conda_retry install -k -y -c conda-forge \
       anaconda-client \
       codecov \

--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -71,8 +71,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv
     && rm -rf ./aws ./awscliv2.zip
 
 # Add core tools to base env
-RUN conda install -y gpuci-tools \
-    || conda install -y gpuci-tools
+RUN wget https://github.com/rapidsai/gpuci-tools/releases/latest/download/tools.tar.gz -O - \
+    | tar -xz -C /usr/local/bin
 
 RUN gpuci_conda_retry install -y \
       anaconda-client \
@@ -86,7 +86,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c conda-forge \
       -c gpuci \
       git \
-      gpuci-tools \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools>50" \

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -18,15 +18,16 @@ SHELL ["/bin/bash", "-c"]
 COPY .condarc /opt/conda/.condarc
 
 # Create rapids conda env and make default
-RUN conda install -y gpuci-tools mamba \
-    || conda install -y gpuci-tools mamba
+RUN conda install -y mamba \
+    || conda install -y mamba
+RUN wget https://github.com/rapidsai/gpuci-tools/releases/latest/download/tools.tar.gz -O - \
+    | tar -xz -C /usr/local/bin
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       git \
-      gpuci-tools \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools>50" \

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -78,8 +78,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     && rm -rf ./aws ./awscliv2.zip
 
 # Add core tools to base env
-RUN conda install -y gpuci-tools \
-    || conda install -y gpuci-tools
+RUN wget https://github.com/rapidsai/gpuci-tools/releases/latest/download/tools.tar.gz -O - \
+    | tar -xz -C /usr/local/bin
 RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
@@ -93,7 +93,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       cudatoolkit=${CUDA_VER} \
       git \
       git-lfs \
-      gpuci-tools \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools>50" \

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -62,8 +62,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv
     && rm -rf ./aws ./awscliv2.zip
 
 # Add core tools to base env
-RUN conda install -y gpuci-tools \
-    || conda install -y gpuci-tools
+RUN wget https://github.com/rapidsai/gpuci-tools/releases/latest/download/tools.tar.gz -O - \
+    | tar -xz -C /usr/local/bin
 RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
@@ -78,7 +78,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       cudatoolkit=${CUDA_VER} \
       git \
       git-lfs \
-      gpuci-tools \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools>50" \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -77,8 +77,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     && rm -rf ./aws ./awscliv2.zip
 
 # Add core tools to base env
-RUN conda install -y gpuci-tools \
-    || conda install -y gpuci-tools
+RUN wget https://github.com/rapidsai/gpuci-tools/releases/latest/download/tools.tar.gz -O - \
+    | tar -xz -C /usr/local/bin
 RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
@@ -92,7 +92,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       cudatoolkit=${CUDA_VER} \
       git \
       git-lfs \
-      gpuci-tools \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools>50" \

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -74,8 +74,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv
     && rm -rf ./aws ./awscliv2.zip
 
 # Add core tools to base env
-RUN conda install -y gpuci-tools \
-    || conda install -y gpuci-tools
+RUN wget https://github.com/rapidsai/gpuci-tools/releases/latest/download/tools.tar.gz -O - \
+    | tar -xz -C /usr/local/bin
 RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov \
@@ -92,7 +92,6 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       cudatoolkit=${CUDA_VER} \
       git \
       git-lfs \
-      gpuci-tools \
       python=${PYTHON_VER} \
       'python_abi=*=*cp*' \
       "setuptools>50" \


### PR DESCRIPTION
This PR moves the `gpuci-tools` install from `conda` to the system level. After merging https://github.com/rapidsai/gpuci-tools/pull/27, all changes to `gpuci-tools` will be packaged in a tarball that can be easily installed with:

```sh
wget https://github.com/rapidsai/gpuci-tools/releases/latest/download/tools.tar.gz -O - \
    | tar -xz -C /usr/local/bin
```

Since `gpuci-tools` is simply a collection of shell scripts, we should eventually remove the `conda` packages for it, since they represent unnecessary overhead.