### PR TITLE
Update conda version to 4.12.0

### DIFF
--- a/miniforge-cuda-driver/centos7.Dockerfile
+++ b/miniforge-cuda-driver/centos7.Dockerfile
@@ -16,7 +16,7 @@ RUN source activate base \
     && gpuci_conda_retry install -k -y -c conda-forge \
       anaconda-client \
       codecov \
-      conda-build=3.20.4 \
+      conda-build=3.21.8 \
       conda-verify \
       ripgrep \
     && chmod -R ugo+w /opt/conda

--- a/miniforge-cuda-driver/ubuntu.Dockerfile
+++ b/miniforge-cuda-driver/ubuntu.Dockerfile
@@ -18,7 +18,7 @@ RUN source activate base \
     && gpuci_conda_retry install -k -y -c conda-forge \
       anaconda-client \
       codecov \
-      conda-build=3.20.4 \
+      conda-build=3.21.8 \
       conda-verify \
       ripgrep \
     && chmod -R ugo+w /opt/conda

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -10,7 +10,7 @@ ARG LINUX_VER
 
 # Define versions and download locations
 ARG ARCH_TYPE=x86_64
-ARG CONDA_VER=4.10.3-10
+ARG CONDA_VER=4.12.0-0
 ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${CONDA_VER}/Miniforge3-${CONDA_VER}-Linux-${ARCH_TYPE}.sh
 
 # Set environment


### PR DESCRIPTION
Also updates conda-build to 3.21.8 which should resolve build errors in https://github.com/rapidsai/integration PRs [here](https://github.com/rapidsai/integration/pull/473)