### PR TITLE
Add `dask/label/dev` channel to `.condarc`

### DIFF
--- a/context/.condarc
+++ b/context/.condarc
@@ -3,6 +3,7 @@ ssl_verify: False
 channels:
   - gpuci
   - rapidsai-nightly
+  - dask/label/dev
   - rapidsai
   - nvidia
   - pytorch


### PR DESCRIPTION
I release now that I forgot to include the changes from #238 and #244 in my #254 PR.

This PR fixes that.