### PR TITLE
Ensure `nvcc` version matches `cudatoolkit` version

### DIFF
--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -61,11 +61,9 @@ RUN wget https://github.com/rapidsai/gpuci-tools/releases/latest/download/tools.
 RUN gpuci_conda_retry install -y \
       anaconda-client \
       codecov
-# FIXME: Install rapids-scout-local
-#      rapids-scout-local
 
 # Create `rapids` conda env and make default
-RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \

--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -65,7 +65,7 @@ RUN gpuci_conda_retry install -y \
 #      rapids-scout-local
 
 # Create `rapids` conda env and make default
-RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -22,7 +22,7 @@ RUN conda install -y mamba \
     || conda install -y mamba
 RUN wget https://github.com/rapidsai/gpuci-tools/releases/latest/download/tools.tar.gz -O - \
     | tar -xz -C /usr/local/bin
-RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
@@ -38,7 +38,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
 RUN if [ "${IMAGE_TYPE}" == "runtime" ] ; then \
-      gpuci_conda_retry install -y -n rapids --freeze-installed \
+      gpuci_mamba_retry install -y -n rapids \
         rapids-notebook-env=${RAPIDS_VER} \
       && gpuci_conda_retry remove -y -n rapids --force-remove \
         rapids-notebook-env=${RAPIDS_VER} ; \

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -81,6 +81,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c conda-forge \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
+      nvcc_linux-64=${CUDA_VER} \
       git \
       git-lfs \
       python=${PYTHON_VER} \

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -76,7 +76,7 @@ RUN gpuci_conda_retry install -y \
       mamba
 
 # Create `rapids` conda env and make default
-RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
@@ -99,7 +99,7 @@ RUN curl -L ${SCCACHE_URL} | tar -C /usr/bin -zf - --wildcards --strip-component
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
+RUN gpuci_mamba_retry install -y -n rapids \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -82,6 +82,12 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-64=${CUDA_VER} \
+      # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of
+      # this migration packages are being built for both versions. However not all packages
+      # have made it to OpenSSL 3. To avoid major solve changes later in the image build,
+      # we pin to OpenSSL 1.1.1 to ensure minimal changes later in the environment
+      # and no lengthy solves or conflicts.
+      # https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1896
       openssl=1.1.1 \
       git \
       git-lfs \

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -82,6 +82,7 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-64=${CUDA_VER} \
+      openssl=1.1.1 \
       git \
       git-lfs \
       python=${PYTHON_VER} \

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -64,7 +64,7 @@ RUN gpuci_conda_retry install -y \
       mamba
 
 # Create `rapids` conda env and make default
-RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
@@ -87,7 +87,7 @@ RUN curl -L ${SCCACHE_URL} | tar -C /usr/bin -zf - --wildcards --strip-component
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
+RUN gpuci_mamba_retry install -y -n rapids \
       rapids-build-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \
     && gpuci_conda_retry remove -y -n rapids --force-remove \

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -70,6 +70,7 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-aarch64=${CUDA_VER} \
+      openssl=1.1.1 \
       git \
       git-lfs \
       python=${PYTHON_VER} \

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -69,6 +69,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c conda-forge \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
+      nvcc_linux-aarch64=${CUDA_VER} \
       git \
       git-lfs \
       python=${PYTHON_VER} \

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -70,6 +70,12 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-aarch64=${CUDA_VER} \
+      # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of
+      # this migration packages are being built for both versions. However not all packages
+      # have made it to OpenSSL 3. To avoid major solve changes later in the image build,
+      # we pin to OpenSSL 1.1.1 to ensure minimal changes later in the environment
+      # and no lengthy solves or conflicts.
+      # https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1896
       openssl=1.1.1 \
       git \
       git-lfs \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -72,6 +72,7 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-64=${CUDA_VER} \
+      openssl=1.1.1 \
       git \
       git-lfs \
       python=${PYTHON_VER} \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -72,6 +72,12 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-64=${CUDA_VER} \
+      # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of
+      # this migration packages are being built for both versions. However not all packages
+      # have made it to OpenSSL 3. To avoid major solve changes later in the image build,
+      # we pin to OpenSSL 1.1.1 to ensure minimal changes later in the environment
+      # and no lengthy solves or conflicts.
+      # https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1896
       openssl=1.1.1 \
       git \
       git-lfs \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -66,7 +66,7 @@ RUN gpuci_conda_retry install -y \
       mamba
 
 # Create `rapids` conda env and make default
-RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
@@ -89,7 +89,7 @@ RUN curl -L ${SCCACHE_URL} | tar -C /usr/bin -zf - --wildcards --strip-component
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
+RUN gpuci_mamba_retry install -y -n rapids \
       rapids-build-env=${RAPIDS_VER} \
       rapids-doc-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -71,6 +71,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c conda-forge \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
+      nvcc_linux-64=${CUDA_VER} \
       git \
       git-lfs \
       python=${PYTHON_VER} \

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -71,6 +71,7 @@ RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       -c rapidsai-nightly \
       cudatoolkit=${CUDA_VER} \
+      nvcc_linux-aarch64=${CUDA_VER} \
       git \
       git-lfs \
       python=${PYTHON_VER} \

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -72,6 +72,7 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c rapidsai-nightly \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-aarch64=${CUDA_VER} \
+      openssl=1.1.1 \
       git \
       git-lfs \
       python=${PYTHON_VER} \

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -72,6 +72,12 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c rapidsai-nightly \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-aarch64=${CUDA_VER} \
+      # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of
+      # this migration packages are being built for both versions. However not all packages
+      # have made it to OpenSSL 3. To avoid major solve changes later in the image build,
+      # we pin to OpenSSL 1.1.1 to ensure minimal changes later in the environment
+      # and no lengthy solves or conflicts.
+      # https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1896
       openssl=1.1.1 \
       git \
       git-lfs \

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -65,7 +65,7 @@ RUN gpuci_conda_retry install -y \
 
 # Create `rapids` conda env and make default
 # TODO: Remove -c rapidsai-nightly
-RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
       -c nvidia \
       -c conda-forge \
       -c gpuci \
@@ -89,7 +89,7 @@ RUN curl -L ${SCCACHE_URL} | tar -C /usr/bin -zf - --wildcards --strip-component
 #
 # Once installed remove the meta-pkg so dependencies can be freely updated &
 # the meta-pkg can be installed again with updates
-RUN gpuci_conda_retry install -y -n rapids --freeze-installed \
+RUN gpuci_mamba_retry install -y -n rapids \
       rapids-build-env=${RAPIDS_VER} \
       rapids-notebook-env=${RAPIDS_VER} \
     && gpuci_conda_retry remove -y -n rapids --force-remove \


### PR DESCRIPTION
This PR ensures that the `nvcc` version installed from `conda` matches the `cudatoolkit` version installed from `conda`.