### PR TITLE
Add `c-compiler` & `cxx-compiler`

### DIFF
--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -80,6 +80,8 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c nvidia \
       -c conda-forge \
       -c gpuci \
+      c-compiler \
+      cxx-compiler \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-64=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -82,6 +82,8 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       c-compiler \
       cxx-compiler \
+      gcc_impl_linux-64=9 \
+      sysroot_linux-64=2.17 \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-64=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -68,6 +68,8 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c nvidia \
       -c conda-forge \
       -c gpuci \
+      c-compiler \
+      cxx-compiler \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-aarch64=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -70,6 +70,8 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       c-compiler \
       cxx-compiler \
+      gcc_impl_linux-aarch64=9 \
+      sysroot_linux-aarch64=2.17 \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-aarch64=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -70,6 +70,8 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c nvidia \
       -c conda-forge \
       -c gpuci \
+      c-compiler \
+      cxx-compiler \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-64=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -72,6 +72,8 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       c-compiler \
       cxx-compiler \
+      gcc_impl_linux-64=9 \
+      sysroot_linux-64=2.17 \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-64=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -72,6 +72,8 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c rapidsai-nightly \
       c-compiler \
       cxx-compiler \
+      gcc_impl_linux-aarch64=9 \
+      sysroot_linux-aarch64=2.17 \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-aarch64=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -70,6 +70,8 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c conda-forge \
       -c gpuci \
       -c rapidsai-nightly \
+      c-compiler \
+      cxx-compiler \
       cudatoolkit=${CUDA_VER} \
       nvcc_linux-aarch64=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of


### PR DESCRIPTION
Install the `c-compiler` & `cxx-compiler` packages alongside `nvcc`, which builds on these. Also pins them to match `integration` repo constraints.

Should also address an issue @galipremsagar discovered where `libcuda.so` symlinks wound up in the `/usr/lib` due to `$CONDA_BUILD_SYSROOT` not being defined. Though PR ( https://github.com/conda-forge/nvcc-feedstock/pull/84 ) will solve this more generally.