### PR TITLE
Remove `nvcc` from images

### DIFF
--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -81,7 +81,6 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c conda-forge \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
-      nvcc_linux-64=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of
       # this migration packages are being built for both versions. However not all packages
       # have made it to OpenSSL 3. To avoid major solve changes later in the image build,

--- a/rapidsai/devel-centos.arm64.Dockerfile
+++ b/rapidsai/devel-centos.arm64.Dockerfile
@@ -69,7 +69,6 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c conda-forge \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
-      nvcc_linux-aarch64=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of
       # this migration packages are being built for both versions. However not all packages
       # have made it to OpenSSL 3. To avoid major solve changes later in the image build,

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -71,7 +71,6 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c conda-forge \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
-      nvcc_linux-64=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of
       # this migration packages are being built for both versions. However not all packages
       # have made it to OpenSSL 3. To avoid major solve changes later in the image build,

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -71,7 +71,6 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       -c rapidsai-nightly \
       cudatoolkit=${CUDA_VER} \
-      nvcc_linux-aarch64=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of
       # this migration packages are being built for both versions. However not all packages
       # have made it to OpenSSL 3. To avoid major solve changes later in the image build,


### PR DESCRIPTION
This PR removes `nvcc` from our CI images since the package has been causing problems.