### PR TITLE
Add a conda update to `miniforge-cuda`

### DIFF
--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -92,6 +92,7 @@ RUN if [ "${LINUX_VER:0:6}" == "centos" ] ; then \
 RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
     && /bin/bash /miniforge.sh -b -p /opt/conda \
     && conda update --all --yes \
+    && conda clean -tipy \
     && rm -f /miniforge.sh \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
     && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \

--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -91,6 +91,7 @@ RUN if [ "${LINUX_VER:0:6}" == "centos" ] ; then \
 # Install miniforge and configure
 RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
     && /bin/bash /miniforge.sh -b -p /opt/conda \
+    && conda update --all --yes \
     && rm -f /miniforge.sh \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
     && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \


### PR DESCRIPTION
Miniforge is shipping with an older version of python which has a CVE. So we will update the conda environment to get the latest python.