### PR TITLE
Update axes to remove 22.08 for branch-22.10

### DIFF
--- a/ci/axis/rapidsai-arm64.yml
+++ b/ci/axis/rapidsai-arm64.yml
@@ -13,7 +13,6 @@ DOCKER_FILE:
   - base-runtime.Dockerfile
 
 RAPIDS_VER:
-  - '22.08'
   - '22.10'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-driver-arm64.yml
+++ b/ci/axis/rapidsai-driver-arm64.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - Dockerfile
 
 RAPIDS_VER:
-  - '22.08'
   - '22.10'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - centos.Dockerfile
 
 RAPIDS_VER:
-  - '22.08'
   - '22.10'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-l4t.yml
+++ b/ci/axis/rapidsai-l4t.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - Dockerfile
 
 RAPIDS_VER:
-  - '22.08'
   - '22.10'
 
 CUDA_VER:

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -13,7 +13,6 @@ DOCKER_FILE:
   - devel-centos.Dockerfile
 
 RAPIDS_VER:
-  - '22.08'
   - '22.10'
 
 CUDA_VER:


### PR DESCRIPTION
Just removing `22.08` versions from all images in `branch-22.10`