### PR TITLE
Update `.condarc` channel priority

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,8 +80,8 @@ ENV PATH=${PATH}:/conda/bin
 # Create a dev conda env
 RUN source activate base \
     && conda create --no-default-packages --override-channels -n dev \
-      -c nvidia \
       -c conda-forge \
+      -c nvidia \
       cudatoolkit=${CUDA_VER} \
       conda-forge::blas \
       python=${PYTHON_VERSION} \

--- a/context/.condarc
+++ b/context/.condarc
@@ -1,12 +1,12 @@
 auto_update_conda: False
 ssl_verify: False
 channels:
-  - gpuci
-  - rapidsai-nightly
+  - conda-forge
   - dask/label/dev
-  - rapidsai
   - nvidia
   - pytorch
-  - conda-forge
+  - rapidsai
+  - rapidsai-nightly
+  - gpuci
 conda-build:
   set_build_id: false

--- a/rapidsai-l4t/Dockerfile
+++ b/rapidsai-l4t/Dockerfile
@@ -64,8 +64,8 @@ RUN gpuci_conda_retry install -y \
 
 # Create `rapids` conda env and make default
 RUN gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
-      -c nvidia \
       -c conda-forge \
+      -c nvidia \
       -c gpuci \
       git \
       python=${PYTHON_VER} \

--- a/rapidsai/base-runtime.Dockerfile
+++ b/rapidsai/base-runtime.Dockerfile
@@ -23,8 +23,8 @@ RUN conda install -y mamba \
 RUN wget https://github.com/rapidsai/gpuci-tools/releases/latest/download/tools.tar.gz -O - \
     | tar -xz -C /usr/local/bin
 RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
-      -c nvidia \
       -c conda-forge \
+      -c nvidia \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       git \

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -77,8 +77,8 @@ RUN gpuci_conda_retry install -y \
 
 # Create `rapids` conda env and make default
 RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
-      -c nvidia \
       -c conda-forge \
+      -c nvidia \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of

--- a/rapidsai/devel-rocky.arm64.Dockerfile
+++ b/rapidsai/devel-rocky.arm64.Dockerfile
@@ -61,8 +61,8 @@ RUN gpuci_conda_retry install -y \
 
 # Create `rapids` conda env and make default
 RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
-      -c nvidia \
       -c conda-forge \
+      -c nvidia \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -67,8 +67,8 @@ RUN gpuci_conda_retry install -y \
 
 # Create `rapids` conda env and make default
 RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
-      -c nvidia \
       -c conda-forge \
+      -c nvidia \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
       # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -66,8 +66,8 @@ RUN gpuci_conda_retry install -y \
 # Create `rapids` conda env and make default
 # TODO: Remove -c rapidsai-nightly
 RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids \
-      -c nvidia \
       -c conda-forge \
+      -c nvidia \
       -c gpuci \
       -c rapidsai-nightly \
       cudatoolkit=${CUDA_VER} \


### PR DESCRIPTION
This PR updates the channel priority in our `.condarc` file. This is to ensure that the `cuda-python` package from `conda-forge` is preferred over the `nvidia` variant. It's important that we use the `conda-forge` variant since that depends on the `cudatoolkit` package, as opposed to the unsupported `cuda-toolkit` package which is depended on by the `nvidia` variant.