### PR TITLE
Remove `22.12` version from `branch-22.10`

### DIFF
--- a/ci/axis/rapidsai-arm64.yml
+++ b/ci/axis/rapidsai-arm64.yml
@@ -14,7 +14,6 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '22.10'
-  - '22.12'
 
 CUDA_VER:
   - 11.2

--- a/ci/axis/rapidsai-driver-arm64.yml
+++ b/ci/axis/rapidsai-driver-arm64.yml
@@ -12,7 +12,6 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '22.10'
-  - '22.12'
 
 CUDA_VER:
   - 11.5

--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -12,7 +12,6 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '22.10'
-  - '22.12'
 
 CUDA_VER:
   - 11.5

--- a/ci/axis/rapidsai-l4t.yml
+++ b/ci/axis/rapidsai-l4t.yml
@@ -12,7 +12,6 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '22.10'
-  - '22.12'
 
 CUDA_VER:
   - 10.2

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -14,7 +14,6 @@ DOCKER_FILE:
 
 RAPIDS_VER:
   - '22.10'
-  - '22.12'
 
 CUDA_VER:
   - 11.5


### PR DESCRIPTION
This PR removes the `22.12` version value from the axes on `branch-22.10`.

This is necessary because we've needed to rebuild the `22.10` images for a hotfix, but don't want to also re-build `22.12` images from this branch.