### PR TITLE
Update channel order

### DIFF
--- a/context/.condarc
+++ b/context/.condarc
@@ -1,12 +1,12 @@
 auto_update_conda: False
 ssl_verify: False
 channels:
-  - conda-forge
-  - dask/label/dev
-  - nvidia
-  - pytorch
   - rapidsai
   - rapidsai-nightly
+  - dask/label/dev
+  - pytorch
+  - conda-forge
+  - nvidia
   - gpuci
 conda-build:
   set_build_id: false


### PR DESCRIPTION
This PR updates the channel priority for our CI images. Apparently they still aren't correct even after the latest edits for the `cuda-python` package issues.