### PR TITLE
Update `branch-23.02`

### DIFF
--- a/ci/axis/rapidsai-arm64.yml
+++ b/ci/axis/rapidsai-arm64.yml
@@ -13,7 +13,6 @@ DOCKER_FILE:
   - base-runtime.Dockerfile
 
 RAPIDS_VER:
-  - '22.12'
   - '23.02'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-driver-arm64.yml
+++ b/ci/axis/rapidsai-driver-arm64.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - Dockerfile
 
 RAPIDS_VER:
-  - '22.12'
   - '23.02'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-driver.yml
+++ b/ci/axis/rapidsai-driver.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - centos.Dockerfile
 
 RAPIDS_VER:
-  - '22.12'
   - '23.02'
 
 CUDA_VER:

--- a/ci/axis/rapidsai-l4t.yml
+++ b/ci/axis/rapidsai-l4t.yml
@@ -11,7 +11,6 @@ DOCKER_FILE:
   - Dockerfile
 
 RAPIDS_VER:
-  - '22.12'
   - '23.02'
 
 CUDA_VER:

--- a/ci/axis/rapidsai.yml
+++ b/ci/axis/rapidsai.yml
@@ -13,7 +13,6 @@ DOCKER_FILE:
   - devel-centos.Dockerfile
 
 RAPIDS_VER:
-  - '22.12'
   - '23.02'
 
 CUDA_VER:

--- a/rapidsai/devel-centos.Dockerfile
+++ b/rapidsai/devel-centos.Dockerfile
@@ -81,13 +81,6 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c nvidia \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
-      # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of
-      # this migration packages are being built for both versions. However not all packages
-      # have made it to OpenSSL 3. To avoid major solve changes later in the image build,
-      # we pin to OpenSSL 1.1.1 to ensure minimal changes later in the environment
-      # and no lengthy solves or conflicts.
-      # https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1896
-      openssl=1.1.1 \
       git \
       git-lfs \
       python=${PYTHON_VER} \

--- a/rapidsai/devel-rocky.arm64.Dockerfile
+++ b/rapidsai/devel-rocky.arm64.Dockerfile
@@ -65,13 +65,6 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c nvidia \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
-      # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of
-      # this migration packages are being built for both versions. However not all packages
-      # have made it to OpenSSL 3. To avoid major solve changes later in the image build,
-      # we pin to OpenSSL 1.1.1 to ensure minimal changes later in the environment
-      # and no lengthy solves or conflicts.
-      # https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1896
-      openssl=1.1.1 \
       git \
       git-lfs \
       python=${PYTHON_VER} \

--- a/rapidsai/devel.Dockerfile
+++ b/rapidsai/devel.Dockerfile
@@ -71,13 +71,6 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c nvidia \
       -c gpuci \
       cudatoolkit=${CUDA_VER} \
-      # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of
-      # this migration packages are being built for both versions. However not all packages
-      # have made it to OpenSSL 3. To avoid major solve changes later in the image build,
-      # we pin to OpenSSL 1.1.1 to ensure minimal changes later in the environment
-      # and no lengthy solves or conflicts.
-      # https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1896
-      openssl=1.1.1 \
       git \
       git-lfs \
       python=${PYTHON_VER} \

--- a/rapidsai/devel.arm64.Dockerfile
+++ b/rapidsai/devel.arm64.Dockerfile
@@ -71,13 +71,6 @@ RUN gpuci_mamba_retry create --no-default-packages --override-channels -n rapids
       -c gpuci \
       -c rapidsai-nightly \
       cudatoolkit=${CUDA_VER} \
-      # Conda-forge is currently migrating from OpenSSL 1.1.1 to OpenSSL 3. As part of
-      # this migration packages are being built for both versions. However not all packages
-      # have made it to OpenSSL 3. To avoid major solve changes later in the image build,
-      # we pin to OpenSSL 1.1.1 to ensure minimal changes later in the environment
-      # and no lengthy solves or conflicts.
-      # https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1896
-      openssl=1.1.1 \
       git \
       git-lfs \
       python=${PYTHON_VER} \


### PR DESCRIPTION
This PR includes two changes:

- Removes `22.12` from `branch-23.02`
- Removes the `openssl` pinning, which is incompatible w/ version 10 of `arrow` (which we're in the process of upgrading to)