### PR TITLE
Update `miniforge` version

### DIFF
--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -10,7 +10,7 @@ ARG LINUX_VER
 
 # Define versions and download locations
 ARG ARCH_TYPE=x86_64
-ARG CONDA_VER=4.12.0-0
+ARG CONDA_VER=22.11.1-2
 ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${CONDA_VER}/Miniforge3-${CONDA_VER}-Linux-${ARCH_TYPE}.sh
 
 # Set environment


### PR DESCRIPTION
This PR updates the `miniforge` version used in our CI images in hopes that it resolves the weird conda errors shown in the log below.

- https://gpuci.gpuopenanalytics.com/job/gpuci/job/gpuci-build-environment-jobs/job/rapidsai/1868/BUILD_IMAGE=gpuci%2Frapidsai,CUDA_VER=11.5,DOCKER_FILE=base-runtime.Dockerfile,FROM_IMAGE=gpuci%2Fminiforge-cuda,IMAGE_NAME=rapidsai,IMAGE_TYPE=base,LINUX_VER=ubuntu20.04,PYTHON_VER=3.10,RAPIDS_VER=23.04/console