### PR TITLE
Remove the micromamba package cache

### DIFF
--- a/miniforge-cuda/Dockerfile
+++ b/miniforge-cuda/Dockerfile
@@ -91,7 +91,7 @@ RUN wget --quiet ${MINIFORGE_URL} -O /miniforge.sh \
     && /bin/bash /miniforge.sh -b -p /opt/conda \
     && conda update --all --yes \
     && conda clean -tipy \
-    && rm -f /miniforge.sh \
+    && rm -rf /miniforge.sh /root/micromamba/ \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
     && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
     && echo "conda activate base" >> ~/.bashrc \


### PR DESCRIPTION
During the installation of `miniforge`, `micromamba` is unpacked into `/root/micromamba`. This leaves outdated packages behind that contain CVEs. Since `micromamba` is only required to bootstrap the `miniforge` installation, we can safely remove the directory after the installation.

For example, you can see [here](https://gpuci.gpuopenanalytics.com/job/gpuci/job/gpuci-build-environment-jobs/job/miniforge-cuda/BUILD_IMAGE=gpuci%2Fminiforge-cuda,CUDA_VER=11.8.0,DOCKER_FILE=Dockerfile,FROM_IMAGE=nvidia%2Fcuda,IMAGE_NAME=miniforge-cuda,IMAGE_TYPE=base,LINUX_VER=ubuntu20.04/2317/console) that an old version of python is unpacked for `micromamba`.