### PR TITLE
Bump unsupported CUDA versions

### DIFF
--- a/ci/axis/miniforge-cuda-arm64.yml
+++ b/ci/axis/miniforge-cuda-arm64.yml
@@ -19,8 +19,8 @@ ARCH_TYPE:
 # it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
   - 11.8.0
-  - 11.5.1
-  - 11.4.1
+  - 11.5.2
+  - 11.4.3
   - 11.2.2
 
 IMAGE_TYPE:
@@ -37,12 +37,12 @@ exclude:
   # - FROM_IMAGE: gpuci/cuda
   #   CUDA_VER: 11.2.2
   # - FROM_IMAGE: gpuci/cuda
-  #   CUDA_VER: 11.4.1
+  #   CUDA_VER: 11.4.3
   # - FROM_IMAGE: nvidia/cuda
-  #   CUDA_VER: 11.5.1
-  - CUDA_VER: 11.5.1
+  #   CUDA_VER: 11.5.2
+  - CUDA_VER: 11.5.2
     LINUX_VER: ubuntu22.04
-  - CUDA_VER: 11.4.1
+  - CUDA_VER: 11.4.3
     LINUX_VER: ubuntu22.04
   - CUDA_VER: 11.2.2
     LINUX_VER: ubuntu22.04

--- a/ci/axis/miniforge-cuda.yml
+++ b/ci/axis/miniforge-cuda.yml
@@ -19,8 +19,8 @@ ARCH_TYPE:
 # it to the existing CUDA_VER var and remove the patch version in run script
 CUDA_VER:
   - 11.8.0
-  - 11.5.1
-  - 11.4.1
+  - 11.5.2
+  - 11.4.3
   - 11.2.2
 
 IMAGE_TYPE:
@@ -42,12 +42,12 @@ exclude:
   # - FROM_IMAGE: gpuci/cuda
   #   CUDA_VER: 11.2.2
   # - FROM_IMAGE: gpuci/cuda
-  #   CUDA_VER: 11.4.1
+  #   CUDA_VER: 11.4.3
   # - FROM_IMAGE: nvidia/cuda
-  #   CUDA_VER: 11.5.1
-  - CUDA_VER: 11.5.1
+  #   CUDA_VER: 11.5.2
+  - CUDA_VER: 11.5.2
     LINUX_VER: ubuntu22.04
-  - CUDA_VER: 11.4.1
+  - CUDA_VER: 11.4.3
     LINUX_VER: ubuntu22.04
   - CUDA_VER: 11.2.2
     LINUX_VER: ubuntu22.04


### PR DESCRIPTION
This PR updates the CUDA versions to the latest supported patch versions.

See:
- https://gitlab.com/nvidia/container-images/cuda/-/issues/209#note_1452067531
- https://gitlab.com/nvidia/container-images/cuda/-/blob/master/doc/container_tags.pdf